### PR TITLE
Fixed external function call on x86/x64 linux and windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ REG_CFLAGS=-g -W
 COMP_CFLAGS=-g -W -D NULLC_NO_EXECUTOR
 
 ifeq ($(config),release)
-	REG_CFLAGS+=-O3 -DNDEBUG
-	COMP_CFLAGS+=-O3 -DNDEBUG
+	REG_CFLAGS+=-O3 -fno-omit-frame-pointer -DNDEBUG
+	COMP_CFLAGS+=-O3 -fno-omit-frame-pointer -DNDEBUG
 endif
 
 ifeq ($(config),coverage)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # Aug 3, 2010
 
 config=debug
+extcall=manual
 
 REG_CFLAGS=-g -W
 COMP_CFLAGS=-g -W -D NULLC_NO_EXECUTOR
@@ -15,6 +16,11 @@ endif
 ifeq ($(config),coverage)
 	REG_CFLAGS+=-coverage
 	COMP_CFLAGS+=-coverage
+endif
+
+ifeq ($(extcall),dyncall)
+	REG_CFLAGS+=-DNULLC_USE_DYNCALL
+	COMP_CFLAGS+=-DNULLC_USE_DYNCALL
 endif
 
 LIB_SOURCES = \
@@ -83,7 +89,6 @@ STDLIB_SOURCES = \
 PUGIXML_SOURCES = \
   external/pugixml/pugixml.cpp
 
-
 STDLIB_TARGETS = \
   temp/lib/canvas.o \
   temp/lib/dynamic.o \
@@ -102,6 +107,14 @@ STDLIB_TARGETS = \
 
 PUGIXML_TARGETS = \
   temp/pugixml.o
+
+DYNCALL_TARGETS = \
+  temp/dyncall/dyncall_api.o \
+  temp/dyncall/dyncall_callvm.o \
+  temp/dyncall/dyncall_callvm_base.o \
+  temp/dyncall/dyncall_struct.o \
+  temp/dyncall/dyncall_vector.o \
+  temp/dyncall_s/dyncall_call.o
 
 all: temp/.dummy temp/compiler/.dummy temp/lib/.dummy temp/tests/.dummy \
     bin/nullcl TestRun bin/ConsoleCalc bin/nullclib
@@ -126,6 +139,12 @@ temp/%.o: NULLC/%.cpp
 ${PUGIXML_TARGETS}: $(PUGIXML_SOURCES)
 	$(CXX) $(REG_CFLAGS) -c $< -o $@
 
+temp/dyncall/%.o: external/dyncall/%.c
+	$(CXX) $(REG_CFLAGS) -c $< -o $@
+
+temp/dyncall_s/%.o: external/dyncall/%.S
+	$(CXX) $(REG_CFLAGS) -c $< -o $@
+
 #~ ${LIB_TARGETS}: ${LIB_SOURCES}
 #~ $(CXX) $(REG_CFLAGS) -c $^ -o $@
 #~
@@ -139,6 +158,10 @@ temp/.dummy:
 temp/compiler/.dummy:
 	mkdir -p temp/compiler
 	touch temp/compiler/.dummy
+	mkdir -p temp/dyncall
+	touch temp/dyncall/.dummy
+	mkdir -p temp/dyncall_s
+	touch temp/dyncall_s/.dummy
 
 temp/lib/.dummy:
 	mkdir -p temp/lib
@@ -148,8 +171,13 @@ temp/tests/.dummy:
 	mkdir -p temp/tests
 	touch temp/tests/.dummy
 
+ifeq ($(extcall),dyncall)
+bin/libnullc.a: ${LIB_TARGETS} ${STDLIB_TARGETS} ${PUGIXML_TARGETS} ${DYNCALL_TARGETS}
+	$(AR) rcs $@ $^
+else
 bin/libnullc.a: ${LIB_TARGETS} ${STDLIB_TARGETS} ${PUGIXML_TARGETS}
 	$(AR) rcs $@ $^
+endif
 
 clean:
 	rm -rf temp/

--- a/NULLC/CodeGen_X86.cpp
+++ b/NULLC/CodeGen_X86.cpp
@@ -1984,7 +1984,12 @@ void GenCodeCmdCall(VMCmd cmd)
 	}else{
 		unsigned int bytesToPop = x86Functions[cmd.argument].bytesToPop;
 
+#if defined(__linux)
+		bool bigReturn = x86Functions[cmd.argument].retType == ExternFuncInfo::RETURN_UNKNOWN;
+#else
 		bool bigReturn = x86Functions[cmd.argument].retType == ExternFuncInfo::RETURN_UNKNOWN && x86Functions[cmd.argument].returnShift;
+#endif
+
 		if(bigReturn)
 			EMIT_OP_NUM(o_push, (int)(intptr_t)ret);
 		EMIT_OP_ADDR_REG(o_mov, sDWORD, paramBase-12, rEDI);

--- a/NULLC/Compiler.cpp
+++ b/NULLC/Compiler.cpp
@@ -2419,7 +2419,7 @@ unsigned int Compiler::GetBytecode(char **bytecode)
 		if(!refFunc->generic)
 		{
 			funcInfo.retType = ExternFuncInfo::RETURN_UNKNOWN;
-			if(refFunc->retType->type == TypeInfo::TYPE_VOID)
+			if(refFunc->retType->type == TypeInfo::TYPE_VOID || refFunc->retType->size == 0)
 				funcInfo.retType = ExternFuncInfo::RETURN_VOID;
 			else if(refFunc->retType->type == TypeInfo::TYPE_FLOAT || refFunc->retType->type == TypeInfo::TYPE_DOUBLE)
 				funcInfo.retType = ExternFuncInfo::RETURN_DOUBLE;

--- a/NULLC/Compiler.cpp
+++ b/NULLC/Compiler.cpp
@@ -2419,10 +2419,15 @@ unsigned int Compiler::GetBytecode(char **bytecode)
 		if(!refFunc->generic)
 		{
 			funcInfo.retType = ExternFuncInfo::RETURN_UNKNOWN;
-			if(refFunc->retType->type == TypeInfo::TYPE_VOID || refFunc->retType->size == 0)
-				funcInfo.retType = ExternFuncInfo::RETURN_VOID;
-			else if(refFunc->retType->type == TypeInfo::TYPE_FLOAT || refFunc->retType->type == TypeInfo::TYPE_DOUBLE)
+			if(refFunc->retType->type == TypeInfo::TYPE_FLOAT || refFunc->retType->type == TypeInfo::TYPE_DOUBLE)
 				funcInfo.retType = ExternFuncInfo::RETURN_DOUBLE;
+#if defined(__linux) && !defined(_M_X64)
+			else if(refFunc->retType->type == TypeInfo::TYPE_VOID)
+				funcInfo.retType = ExternFuncInfo::RETURN_VOID;
+#else
+			else if(refFunc->retType->type == TypeInfo::TYPE_VOID || refFunc->retType->size == 0)
+				funcInfo.retType = ExternFuncInfo::RETURN_VOID;
+#endif
 #if defined(NULLC_COMPLEX_RETURN) && defined(__linux)
 			else if(refFunc->retType->type == TypeInfo::TYPE_CHAR ||
 				refFunc->retType->type == TypeInfo::TYPE_SHORT ||

--- a/NULLC/Executor.cpp
+++ b/NULLC/Executor.cpp
@@ -152,17 +152,19 @@ bool HasIntegerMembersInRange(ExternTypeInfo &type, unsigned fromOffset, unsigne
 	{
 		ExternMemberInfo &member = linker->exTypeExtra[type.memberOffset + m];
 
-		if(member.offset >= fromOffset && member.offset < toOffset)
-		{
-			ExternTypeInfo &memberType = linker->exTypes[member.type];
+		ExternTypeInfo &memberType = linker->exTypes[member.type];
 
-			if(memberType.type == ExternTypeInfo::TYPE_COMPLEX)
-			{
-				if(HasIntegerMembersInRange(memberType, fromOffset - member.offset, toOffset - member.offset, linker))
-					return true;
-			}else if(memberType.type != ExternTypeInfo::TYPE_FLOAT && memberType.type != ExternTypeInfo::TYPE_DOUBLE){
+		if(memberType.type == ExternTypeInfo::TYPE_COMPLEX)
+		{
+			// Handle opaque types
+			if(memberType.size > 0 && memberType.memberCount == 0 && member.offset >= fromOffset && member.offset < toOffset)
 				return true;
-			}
+
+			if(HasIntegerMembersInRange(memberType, fromOffset - member.offset, toOffset - member.offset, linker))
+				return true;
+		}else if(memberType.type != ExternTypeInfo::TYPE_FLOAT && memberType.type != ExternTypeInfo::TYPE_DOUBLE){
+			if(member.offset >= fromOffset && member.offset < toOffset)
+				return true;
 		}
 	}
 

--- a/NULLC/Executor.cpp
+++ b/NULLC/Executor.cpp
@@ -2197,8 +2197,10 @@ bool Executor::RunExternalFunction(unsigned int funcID, unsigned int extraPopDW)
 
 	dcReset(dcCallVM);
 
-#if !defined(_M_X64) || defined(_WIN64)
+#if defined(_WIN64)
 	bool returnByPointer = func.returnShift > 1;
+#elif !defined(_M_X64)
+	bool returnByPointer = true;
 #else
 	ExternTypeInfo &funcType = exTypes[func.funcType];
 
@@ -2356,7 +2358,7 @@ bool Executor::RunExternalFunction(unsigned int funcID, unsigned int extraPopDW)
 		*(long long*)newStackPtr = dcCallLongLong(dcCallVM, fPtr);
 		break;
 	case ExternFuncInfo::RETURN_UNKNOWN:
-#if !defined(_M_X64) || defined(_WIN64)
+#if defined(_WIN64)
 		if(func.returnShift == 1)
 		{
 			newStackPtr -= 1;
@@ -2368,6 +2370,12 @@ bool Executor::RunExternalFunction(unsigned int funcID, unsigned int extraPopDW)
 			// copy return value on top of the stack
 			memcpy(newStackPtr, ret, exFunctions[funcID].returnShift * 4);
 		}
+#elif !defined(_M_X64)
+		dcCallPointer(dcCallVM, fPtr);
+
+		newStackPtr -= exFunctions[funcID].returnShift;
+		// copy return value on top of the stack
+		memcpy(newStackPtr, ret, exFunctions[funcID].returnShift * 4);
 #else
 		if(returnByPointer)
 		{

--- a/NULLC/Executor.cpp
+++ b/NULLC/Executor.cpp
@@ -157,13 +157,18 @@ bool HasIntegerMembersInRange(ExternTypeInfo &type, unsigned fromOffset, unsigne
 		if(memberType.type == ExternTypeInfo::TYPE_COMPLEX)
 		{
 			// Handle opaque types
-			if(memberType.size > 0 && memberType.memberCount == 0 && member.offset >= fromOffset && member.offset < toOffset)
-				return true;
+			bool opaqueType = memberType.subCat != ExternTypeInfo::CAT_CLASS || memberType.memberCount == 0;
 
-			if(HasIntegerMembersInRange(memberType, fromOffset - member.offset, toOffset - member.offset, linker))
-				return true;
+			if(opaqueType)
+			{
+				if(member.offset + memberType.size > fromOffset && member.offset < toOffset)
+					return true;
+			}else{
+				if(HasIntegerMembersInRange(memberType, fromOffset - member.offset, toOffset - member.offset, linker))
+					return true;
+			}
 		}else if(memberType.type != ExternTypeInfo::TYPE_FLOAT && memberType.type != ExternTypeInfo::TYPE_DOUBLE){
-			if(member.offset >= fromOffset && member.offset < toOffset)
+			if(member.offset + memberType.size > fromOffset && member.offset < toOffset)
 				return true;
 		}
 	}

--- a/NULLC/Executor.cpp
+++ b/NULLC/Executor.cpp
@@ -277,7 +277,7 @@ unsigned int Executor::CreateFunctionGateway(FastVector<unsigned char>& code, un
 				break;
 
 			// If the class if being divided in the middle, between registers and stack, sent through stack
-			if(usedIRegs + requredIRegs > NULLC_X64_IREGARGS)// || usedFRegs + requredFRegs > NULLC_X64_FREGARGS)
+			if(usedIRegs + requredIRegs > NULLC_X64_IREGARGS || usedFRegs + requredFRegs > NULLC_X64_FREGARGS)
 				break;
 
 			// Request registers

--- a/external/dyncall/dyncall_call_x64-att.S
+++ b/external/dyncall/dyncall_call_x64-att.S
@@ -24,7 +24,7 @@
 */
 
 
-#include "../portasm/portasm-x64-att.S"
+#include "portasm-x64-att.S"
 
 BEGIN_ASM
 

--- a/external/dyncall/dyncall_call_x86.S
+++ b/external/dyncall/dyncall_call_x86.S
@@ -24,7 +24,7 @@
 */
 
 
-#include "../portasm/portasm-x86.S"
+#include "portasm-x86.S"
 BEGIN_ASM
 /* ============================================================================
    DynCall Call Kernels for X86 Architecture

--- a/external/dyncall/dyncall_call_x86.S
+++ b/external/dyncall/dyncall_call_x86.S
@@ -64,7 +64,7 @@ BEGIN_PROC(dcCall_x86_cdecl)
 	MOVL(DWORD(EBP,16),ECX)		/* ECX = arg buffer size */
 	ADDL(LIT(15),ECX)		/* ECX = align(ECX,16) */
 	ANDL(LIT(-16),ECX)
-	MOVL(ECX,DWORD(EBP,16))		/* save ECX. */
+	MOVL(ESP,DWORD(EBP,16))		/* save ECX. */
 	SUBL(ECX,ESP)			/* allocate stack size */
 	MOVL(ESP,EDI)			/* EDI = stack ptr */			
 	
@@ -78,7 +78,7 @@ BEGIN_PROC(dcCall_x86_cdecl)
 
 	REP(MOVSB)
 	CALL_DWORD(EBP,8)
-	ADDL(DWORD(EBP,16),ESP)
+	MOVL(DWORD(EBP,16),ESP)
 	POP(EDI)
 	POP(ESI)
 	MOVL(EBP,ESP)

--- a/external/dyncall/dyncall_callvm.h
+++ b/external/dyncall/dyncall_callvm.h
@@ -80,6 +80,12 @@ typedef DCfloat      (DCfloatvmfunc)     (DCCallVM* vm,DCpointer funcptr);
 typedef DCdouble     (DCdoublevmfunc)    (DCCallVM* vm,DCpointer funcptr);
 typedef DCpointer    (DCpointervmfunc)   (DCCallVM* vm,DCpointer funcptr);
 
+// x64 on linux has a special way of returning aggregates <= 16 bytes
+typedef DCcomplexdd    (DCcomplexddvmfunc)   (DCCallVM* vm,DCpointer funcptr);
+typedef DCcomplexdl    (DCcomplexdlvmfunc)   (DCCallVM* vm,DCpointer funcptr);
+typedef DCcomplexld    (DCcomplexldvmfunc)   (DCCallVM* vm,DCpointer funcptr);
+typedef DCcomplexll    (DCcomplexllvmfunc)   (DCCallVM* vm,DCpointer funcptr);
+
 /* Common base functions for CallVM implementations. */
 
 void dc_callvm_base_init(DCCallVM *pInstance, DCCallVM_vt* pVTable);

--- a/external/dyncall/dyncall_callvm_x64.c
+++ b/external/dyncall/dyncall_callvm_x64.c
@@ -132,7 +132,7 @@ static void dc_callvm_argFloat_x64(DCCallVM* in_self, DCfloat x)
   if(self->mRegCount.f < numFloatRegs)
     *(DCfloat*)&self->mRegData.f[self->mRegCount.f++] = x;
   else
-    dcVecAppend(&self->mVecHead, &f.f, sizeof(DCdouble));
+    dcVecAppend(&self->mVecHead, &f.f, sizeof(DCdouble)); // This is a very strange way to align stack on 8-byte boundary
 }
 
 
@@ -215,6 +215,43 @@ DCCallVM_vt gVT_x64 =
 , NULL /* callStruct */
 };
 
+DCcomplexdd dcCallComplexDD(DCCallVM* vm, DCpointer funcptr)
+{
+	return ((DCcomplexddvmfunc*)&dc_callvm_call_x64)(vm, funcptr);
+}
+DCcomplexdl dcCallComplexDL(DCCallVM* vm, DCpointer funcptr)
+{
+	return ((DCcomplexdlvmfunc*)&dc_callvm_call_x64)(vm, funcptr);
+}
+DCcomplexld dcCallComplexLD(DCCallVM* vm, DCpointer funcptr)
+{
+	return ((DCcomplexldvmfunc*)&dc_callvm_call_x64)(vm, funcptr);
+}
+DCcomplexll dcCallComplexLL(DCCallVM* vm, DCpointer funcptr)
+{
+	return ((DCcomplexllvmfunc*)&dc_callvm_call_x64)(vm, funcptr);
+}
+
+void dcArgStack(DCCallVM* in_self, void *ptr, unsigned size)
+{
+	DCCallVM_x64* self = (DCCallVM_x64*)in_self;
+
+	dcVecAppend(&self->mVecHead, ptr, size);
+}
+
+int dcFreeIRegs(DCCallVM* in_self)
+{
+	DCCallVM_x64* self = (DCCallVM_x64*)in_self;
+
+	return numIntRegs - self->mRegCount.i;
+}
+
+int dcFreeFRegs(DCCallVM* in_self)
+{
+	DCCallVM_x64* self = (DCCallVM_x64*)in_self;
+
+	return numFloatRegs - self->mRegCount.f;
+}
 
 DCCallVM* dcNewCallVM_x64(DCsize size) 
 {

--- a/external/dyncall/dyncall_types.h
+++ b/external/dyncall/dyncall_types.h
@@ -61,6 +61,12 @@ typedef double          DCdouble;
 typedef DC_POINTER      DCpointer;
 typedef const char*     DCstring;
 
+// x64 on linux has a special way of returning aggregates <= 16 bytes
+typedef struct{ double a; double b; } DCcomplexdd;
+typedef struct{ double a; DC_LONG_LONG b; } DCcomplexdl;
+typedef struct{ DC_LONG_LONG a; double b; } DCcomplexld;
+typedef struct{ DC_LONG_LONG a; DC_LONG_LONG b; } DCcomplexll;
+
 typedef size_t          DCsize;
 
 #define DC_TRUE   1

--- a/external/dyncall/portasm-x64-att.S
+++ b/external/dyncall/portasm-x64-att.S
@@ -1,0 +1,154 @@
+/*
+
+ Package: dyncall
+ Library: portasm
+ File: portasm/portasm-x64-att.S
+ Description: Portable Assembler Macros for X64
+ License:
+
+   Copyright (c) 2011 Daniel Adler <dadler@uni-goettingen.de>
+
+   Permission to use, copy, modify, and distribute this software for any
+   purpose with or without fee is hereby granted, provided that the above
+   copyright notice and this permission notice appear in all copies.
+
+   THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+   WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+   ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+   WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+   ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+
+/* Common macros. */
+#define XCONCAT(A,B) A##B
+#if defined(GEN_MASM)
+/* MASM syntax. */
+.CODE
+#  define BEGIN_ASM
+#  define END_ASM END
+#  define GLOBAL(X) X PROC
+#  define BEGIN_PROC(X) 	OPTION PROLOGUE:NONE, EPILOGUE:NONE
+#  define END_PROC(X)   X ENDP
+#  define PUSH(R) push R
+#  define POP(R) pop R
+#  define MOV(S,D)  mov D,S
+#  define MOVB(S,D) mov D,S
+#  define MOVL(S,D) mov D,S
+#  define ADDL(S,D) add D,S
+#  define ANDL(S,D) and D,S
+#  define SUBL(S,D) sub D,S
+#  define SHRL(S,D) shr D,S
+#  define MOVQ(S,D) movq D,S
+#  define ADD(S,D)  add D,S
+#  define AND(S,D)  and D,S
+#  define SUB(S,D)  sub D,S
+#  define SHR(S,D)  shr D,S
+#  define MOVD(S,D) movd D,S
+#  define RET() ret
+#  define CALL_DWORD(R,OFF) call DWORD(R,OFF)
+#  define REP(X) rep X
+#  define MOVSB movsb
+#  define MOVSW movsw
+#  define MOVSD(S,D)  movsd D,S
+#  define MOVSDX(S,D) movsdx D,S
+#  define DWORD(R,OFF) dword ptr [R+OFF]
+#  define QWORD(R,OFF) qword ptr [R+OFF]
+#  define LIT(X) X
+#  define INT(X) int X
+#  define HEX(X) XCONCAT(X,h)
+#  define CALL(X) call X
+#  define CALL_REG(X) call X
+#  define LEA(S,D) lea D,S
+#  define SET(K,V) K = V
+#  define JE(X) je X
+#  define JNE(X) jne X
+#  define CMP(A,B) cmp B,A
+#  define LOCAL(X) X
+#else
+/* GNU/SunPro Assembler AT&T Syntax */
+	.text
+#  define BEGIN_ASM
+#  define END_ASM
+#  if defined(__APPLE__) || defined(__Darwin__)
+#    define CSYM(X) _##X
+#  else
+#    define CSYM(X) X
+#  endif
+#  define RAX %rax
+#  define RBX %rbx
+#  define RCX %rcx
+#  define RDX %rdx
+#  define RSI %rsi
+#  define RDI %rdi
+#  define RBP %rbp
+#  define RSP %rsp
+#  define R8   %r8
+#  define R9   %r9
+#  define R10  %r10
+#  define R11  %r11
+#  define R12  %r12
+#  define R13  %r13
+#  define R14  %r14
+#  define R15  %r15
+#  define XMM0 %xmm0
+#  define XMM1 %xmm1
+#  define XMM2 %xmm2
+#  define XMM3 %xmm3
+#  define XMM4 %xmm4
+#  define XMM5 %xmm5
+#  define XMM6 %xmm6
+#  define XMM7 %xmm7
+#  define AL   %al
+#  define AH   %ah
+#  define BL   %bl
+#  define BH   %bh
+#  define CL   %cl
+#  define CH   %ch
+#  define DL   %dl
+#  define DH   %dh
+#  define GLOBAL(X) .globl CSYM(X)
+#  define BEGIN_PROC(X)  CSYM(X):
+#  define END_PROC(X)
+#  define PUSH(R) pushq R
+#  define POP(R) popq R
+#  define MOV(S,D)  movq S,D
+#  define MOVB(S,D) movb S,D
+#  define MOVL(S,D) movl S,D
+#  define ADDL(S,D) addl S,D
+#  define ANDL(S,D) andl S,D
+#  define SUBL(S,D) subl S,D
+#  define SHRL(S,D) shrl S,D
+#  define MOVQ(S,D) movq S,D
+#  define ADD(S,D) addq S,D
+#  define AND(S,D) andq S,D
+#  define SUB(S,D) subq S,D
+#  define SHR(S,D) shrq S,D
+#  define MOVD(S,D) movd S,D
+#  define RET() ret
+#  define CALL_DWORD(R,OFF) call *DWORD(R,OFF)
+#  define REP(X) rep X
+#  define MOVSB movsb
+#  define MOVSW movsw
+#  define MOVSD(S,D) movsd S,D
+#  define DWORD(R,OFF) OFF(R)
+#  define QWORD(R,OFF) OFF(R)
+#  define LIT(X) $X
+#  define INT(X) int X
+#  define HEX(X) XCONCAT(0x,X)
+#  define CALL(X) call X
+#  define CALL_REG(X) call *X
+#  define LEA(A,B) lea A,B
+#  define CMP(A,B) cmp A,B
+#  define CMPB(A,B) cmpb A,B
+#  define JE(X)    je X
+#  define JNE(X)    jne X
+#  define FLDS(X)  flds X
+#  define FLDL(X)  fldl X
+#  define SET(K,V) .set K,V
+#  define LOCAL(X) .X
+#endif
+

--- a/external/dyncall/portasm-x86.S
+++ b/external/dyncall/portasm-x86.S
@@ -1,0 +1,125 @@
+/*
+
+ Package: dyncall
+ Library: portasm
+ File: portasm/portasm-x86.S
+ Description: Portable Assembler Macros for x86
+ License:
+
+   Copyright (c) 2011 Daniel Adler <dadler@uni-goettingen.de>
+
+   Permission to use, copy, modify, and distribute this software for any
+   purpose with or without fee is hereby granted, provided that the above
+   copyright notice and this permission notice appear in all copies.
+
+   THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+   WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+   ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+   WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+   ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+
+/* Common macros. */
+#define XCONCAT(A,B) A##B
+/* MASM syntax. */
+#if defined(GEN_MASM)
+.386
+.MODEL FLAT
+.CODE
+#  define BEGIN_ASM
+#  define END_ASM END
+#  define GLOBAL(X) _##X PROC
+#  define BEGIN_PROC(X) 	OPTION PROLOGUE:NONE, EPILOGUE:NONE
+#  define END_PROC(X)   _##X ENDP
+#  define PUSH(R) push R
+#  define POP(R) pop R
+#  define MOVL(S,D) mov D,S
+#  define ADDL(S,D) add D,S
+#  define ANDL(S,D) and D,S
+#  define SUBL(S,D) sub D,S
+#  define SHRL(S,D) shr D,S
+#  define RET() ret
+#  define CALL_DWORD(R,OFF) call DWORD(R,OFF)
+#  define REP(X) rep X
+#  define MOVSB movsb
+#  define MOVSW movsw
+#  define MOVSD movsd
+#  define DWORD(R,OFF) dword ptr [R+OFF]
+#  define QWORD(R,OFF) qword ptr [R+OFF]
+#  define LIT(X) X
+#  define INT(X) int X
+#  define HEX(X) XCONCAT(X,h)
+#  define CALL(X) call X
+#  define LEA(S,D) lea D,S
+#  define ADD(S,D) add D,S
+#  define CMP(S,D) cmp D,S
+#  define JE(T) je T
+#  define FLDS(OP) fld OP
+#  define FLDL(OP) fld OP
+#  define LOCAL(NAME) NAME
+#else
+/* GNU/SunPro Assembler AT&T Syntax */
+	.text
+#  define BEGIN_ASM
+#  define END_ASM 
+#  if defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW__) || defined(__APPLE__) || defined(__Darwin__)
+#    define CSYM(X) _##X
+#  else
+#    define CSYM(X) X
+#  endif
+/* Systems that work without '%' prefix: MinGW,Apple */
+#  define EAX %eax
+#  define EBX %ebx
+#  define ECX %ecx
+#  define EDX %edx
+#  define ESI %esi
+#  define EDI %edi
+#  define EBP %ebp
+#  define ESP %esp
+#  define AL  %al
+#  define AH  %ah
+#  define BL  %bl
+#  define BH  %bh
+#  define CL  %cl
+#  define CH  %ch
+#  define DL  %dl
+#  define DH  %dh
+#  define GLOBAL(X) .globl CSYM(X)
+#  define BEGIN_PROC(X)  CSYM(X):
+#  define END_PROC(X)
+#  define PUSH(R) pushl R
+#  define POP(R) popl R
+#  define MOVL(S,D) movl S,D
+#  define ADDL(S,D) addl S,D
+#  define ANDL(S,D) andl S,D
+#  define SUBL(S,D) subl S,D
+#  define SHRL(S,D) shrl S,D
+#  define RET() ret
+#  define CALL_DWORD(R,OFF) call *DWORD(R,OFF)
+#  define REP(X) rep; X
+#  define MOVSB movsb
+#  define MOVSW movsw
+#  define MOVSD movsd
+#  define DWORD(R,OFF) OFF(R)
+#  define QWORD(R,OFF) OFF(R)
+#  if defined(__SUNPRO_C)
+#    define LIT(X) $X
+#  else
+#    define LIT(X) XCONCAT($,X)
+#  endif
+#  define INT(X) int X
+#  define HEX(X) XCONCAT(0x,X)
+#  define CALL(X) call X
+#  define LEA(A,B) lea A,B
+#  define CMP(A,B) cmp A,B
+#  define JE(X)    je X
+#  define FLDS(X)  flds X
+#  define FLDL(X)  fldl X
+#  define ADD(A,B) add A,B
+#  define LOCAL(X) .X
+#endif
+

--- a/tests/TestExternalCall.cpp
+++ b/tests/TestExternalCall.cpp
@@ -4,10 +4,6 @@
 
 #include <stdint.h>
 
-#if defined(_M_X64) && !defined(_WIN64) && !defined(NULLC_USE_DYNCALL)
-	#define AMD64_UNIMPLEMENTED_CALLS_20150827
-#endif
-
 int TestInt(int a)
 {
 	return a;
@@ -532,11 +528,8 @@ const char *testExternalCallClass4 = "import test.extF; Long x; x.a = -4; return
 TEST_RESULT("External function call. long inside a class, argument in registers.", testExternalCallClass4, "1");
 const char *testExternalCallClass5 = "import test.extF; Float x; x.a = -5; return Call(x);";
 TEST_RESULT("External function call. float inside a class, argument in registers.", testExternalCallClass5, "1");
-
-#if !defined(AMD64_UNIMPLEMENTED_CALLS_20150827)
 const char *testExternalCallClass6 = "import test.extF; Double x; x.a = -6; return Call(x);";
 TEST_RESULT("External function call. double inside a class, argument in registers.", testExternalCallClass6, "1");
-#endif
 
 LOAD_MODULE_BIND(test_extG, "test.extG", "class Zomg{ long x,y,z; } int Call(Zomg a);")
 {
@@ -599,7 +592,6 @@ Zomg z; z.x = -1; z.y = &u;\r\n\
 return Call(z);";
 TEST_RESULT("External function call. { int; int ref; } in argument.", testExternalCallG6, "1");
 
-#if !defined(AMD64_UNIMPLEMENTED_CALLS_20150827)
 LOAD_MODULE_BIND(test_extG7, "test.extG7", "class Zomg{ float x; double y; } int Call(Zomg a);")
 {
 	nullcBindModuleFunction("test.extG7", (void (*)())TestExtG7, "Call", 0);
@@ -674,7 +666,6 @@ const char	*testExternalCallG11 =
 Zomg z; z.x = { 1, 2 };\r\n\
 return Call(z);";
 TEST_RESULT("External function call. { int[]; } in argument.", testExternalCallG11, "1");
-#endif
 
 LOAD_MODULE_BIND(test_extG2b, "test.extG2b", "class Zomg{ char x; int y; } Zomg Call(Zomg a);")
 {
@@ -840,7 +831,6 @@ LOAD_MODULE_BIND(test_big1, "test.big1", "class X{ int a, b, c, d; } X Call();")
 const char	*testBigReturnType1 = "import test.big1;\r\n X x; x = Call(); return x.a == 1 && x.b == 2 && x.c == 3 && x.d == 4;";
 TEST_RESULT("External function call. Big return type 1.", testBigReturnType1, "1");
 
-#if !defined(AMD64_UNIMPLEMENTED_CALLS_20150827)
 struct ReturnBig2{ float a, b, c; };
 ReturnBig2 TestReturnBig2()
 {
@@ -866,7 +856,6 @@ LOAD_MODULE_BIND(test_big3, "test.big3", "class X{ float a; double b; } X Call()
 }
 const char	*testBigReturnType3 = "import test.big3;\r\n X x; x = Call(); return x.a == 1.0f && x.b == 2.0;";
 TEST_RESULT("External function call. Big return type 3.", testBigReturnType3, "1");
-#endif
 
 struct ReturnBig4{ int a; float b; };
 ReturnBig4 TestReturnBig4()
@@ -881,7 +870,6 @@ LOAD_MODULE_BIND(test_big4, "test.big4", "class X{ int a; float b; } X Call();")
 const char	*testBigReturnType4 = "import test.big4;\r\n X x; x = Call(); return x.a == 1 && x.b == 2.0;";
 TEST_RESULT("External function call. Big return type 4.", testBigReturnType4, "1");
 
-#if !defined(AMD64_UNIMPLEMENTED_CALLS_20150827)
 struct ReturnBig5{ int a; double b; };
 ReturnBig5 TestReturnBig5()
 {
@@ -974,7 +962,6 @@ LOAD_MODULE_BIND(test_small3, "test.small3", "class X{} X Call();")
 }
 const char	*testSmallReturnType3 = "import test.small3;\r\n X x; x = Call(); return 1;";
 TEST_RESULT("External function call. Small return type 3.", testSmallReturnType3, "1");
-#endif
 
 #endif
 

--- a/tests/TestExternalCall.cpp
+++ b/tests/TestExternalCall.cpp
@@ -667,6 +667,24 @@ Zomg z; z.x = { 1, 2 };\r\n\
 return Call(z);";
 TEST_RESULT("External function call. { int[]; } in argument.", testExternalCallG11, "1");
 
+struct TestExtG12Foo{ double a; double b; };
+int TestExtG12(float x, float y, float z, TestExtG12Foo a, TestExtG12Foo b, TestExtG12Foo c)
+{
+	return x == 1.0 && y == 2.0 && z == 3.0 && a.a == 4.0 && a.b == 5.0 && b.a == 6.0 && b.b == 7.0 && c.a == 8.0 && c.b == 9.0;
+}
+
+LOAD_MODULE_BIND(test_extG12, "test.extG12", "class Zomg{ double a; double b; } int Call(float x, y, z, Zomg a, b, c);")
+{
+	nullcBindModuleFunction("test.extG12", (void (*)())TestExtG12, "Call", 0);
+}
+const char	*testExternalCallG12 =
+"import test.extG12;\r\n\
+Zomg a; a.a = 4; a.b = 5;\r\n\
+Zomg b; b.a = 6; b.b = 7;\r\n\
+Zomg c; c.a = 8; c.b = 9;\r\n\
+return Call(1, 2, 3, a, b, c);";
+TEST_RESULT("External function call. Floating point register overflow mid argument.", testExternalCallG12, "1");
+
 LOAD_MODULE_BIND(test_extG2b, "test.extG2b", "class Zomg{ char x; int y; } Zomg Call(Zomg a);")
 {
 	nullcBindModuleFunction("test.extG2b", (void (*)())TestExtG2b, "Call", 0);

--- a/tests/TestExternalCall.cpp
+++ b/tests/TestExternalCall.cpp
@@ -609,6 +609,38 @@ const char	*testExternalCallG7 =
 Zomg z; z.x = -1; z.y = -2;\r\n\
 return Call(z);";
 TEST_RESULT("External function call. { float; double; } in argument.", testExternalCallG7, "1");
+
+struct TestExtG8Foo{ float a; float b; int c; };
+int TestExtG8(TestExtG8Foo x)
+{
+	return x.a == -1.0f && x.b == -2.0f && x.c == -3;
+}
+
+LOAD_MODULE_BIND(test_extG8, "test.extG8", "class Zomg{ float x; float y; int z; } int Call(Zomg a);")
+{
+	nullcBindModuleFunction("test.extG8", (void (*)())TestExtG8, "Call", 0);
+}
+const char	*testExternalCallG8 =
+"import test.extG8;\r\n\
+Zomg z; z.x = -1; z.y = -2; z.z = -3;\r\n\
+return Call(z);";
+TEST_RESULT("External function call. { float; float; int; } in argument.", testExternalCallG8, "1");
+
+struct TestExtG9Foo{ long long a; float b; float c; };
+int TestExtG9(TestExtG9Foo x)
+{
+	return x.a == -1 && x.b == -2.0f && x.c == -3.0f;
+}
+
+LOAD_MODULE_BIND(test_extG9, "test.extG9", "class Zomg{ long x; float y; float z; } int Call(Zomg a);")
+{
+	nullcBindModuleFunction("test.extG9", (void (*)())TestExtG9, "Call", 0);
+}
+const char	*testExternalCallG9 =
+"import test.extG9;\r\n\
+Zomg z; z.x = -1; z.y = -2; z.z = -3;\r\n\
+return Call(z);";
+TEST_RESULT("External function call. { long; float; float; } in argument.", testExternalCallG9, "1");
 #endif
 
 LOAD_MODULE_BIND(test_extG2b, "test.extG2b", "class Zomg{ char x; int y; } Zomg Call(Zomg a);")
@@ -833,15 +865,82 @@ TEST_RESULT("External function call. Big return type 5.", testBigReturnType5, "1
 struct ReturnBig6{ double a; int b; };
 ReturnBig6 TestReturnBig6()
 {
-	ReturnBig6 x = { 1, 2 };
+	ReturnBig6 x = { 4, 8 };
 	return x;
 }
 LOAD_MODULE_BIND(test_big6, "test.big6", "class X{ double a; int b; } X Call();")
 {
 	nullcBindModuleFunction("test.big6", (void (*)())TestReturnBig6, "Call", 0);
 }
-const char	*testBigReturnType6 = "import test.big6;\r\n X x; x = Call(); return x.a == 1 && x.b == 2.0;";
+const char	*testBigReturnType6 = "import test.big6;\r\n X x; x = Call(); return x.a == 4 && x.b == 8.0;";
 TEST_RESULT("External function call. Big return type 6.", testBigReturnType6, "1");
+
+struct ReturnBig7{ float a; int b; };
+ReturnBig7 TestReturnBig7()
+{
+	ReturnBig7 x = { 2, 16 };
+	return x;
+}
+
+LOAD_MODULE_BIND(test_big7, "test.big7", "class X{ float a; int b; } X Call();")
+{
+	nullcBindModuleFunction("test.big7", (void (*)())TestReturnBig7, "Call", 0);
+
+}
+const char	*testBigReturnType7 = "import test.big7;\r\n X x; x = Call(); return x.a == 2 && x.b == 16.0;";
+TEST_RESULT("External function call. Big return type 7.", testBigReturnType7, "1");
+
+struct ReturnBig8{ float a; float b; int c; };
+ReturnBig8 TestReturnBig8()
+{
+	ReturnBig8 x = { 4, 8, 16 };
+	return x;
+}
+LOAD_MODULE_BIND(test_big8, "test.big8", "class X{ float a; float b; int c; } X Call();")
+{
+	nullcBindModuleFunction("test.big8", (void (*)())TestReturnBig8, "Call", 0);
+}
+const char	*testBigReturnType8 = "import test.big8;\r\n X x; x = Call(); return x.a == 4 && x.b == 8.0 && x.c == 16.0;";
+TEST_RESULT("External function call. Big return type 8.", testBigReturnType8, "1");
+
+struct ReturnSmall1{ float a; };
+ReturnSmall1 TestReturnSmall1()
+{
+	ReturnSmall1 x = { 4 };
+	return x;
+}
+LOAD_MODULE_BIND(test_small1, "test.small1", "class X{ float a; } X Call();")
+{
+	nullcBindModuleFunction("test.small1", (void (*)())TestReturnSmall1, "Call", 0);
+}
+const char	*testSmallReturnType1 = "import test.small1;\r\n X x; x = Call(); return x.a == 4.0f;";
+TEST_RESULT("External function call. Small return type 1.", testSmallReturnType1, "1");
+
+struct ReturnSmall2{ double a; };
+ReturnSmall2 TestReturnSmall2()
+{
+	ReturnSmall2 x = { 6 };
+	return x;
+}
+LOAD_MODULE_BIND(test_small2, "test.small2", "class X{ double a; } X Call();")
+{
+	nullcBindModuleFunction("test.small2", (void (*)())TestReturnSmall2, "Call", 0);
+}
+const char	*testSmallReturnType2 = "import test.small2;\r\n X x; x = Call(); return x.a == 6.0;";
+TEST_RESULT("External function call. Small return type 2.", testSmallReturnType2, "1");
+
+struct ReturnSmall3{ };
+ReturnSmall3 TestReturnSmall3()
+{
+	ReturnSmall3 x;
+	return x;
+}
+LOAD_MODULE_BIND(test_small3, "test.small3", "class X{} X Call();")
+{
+	nullcBindModuleFunction("test.small3", (void (*)())TestReturnSmall3, "Call", 0);
+}
+const char	*testSmallReturnType3 = "import test.small3;\r\n X x; x = Call(); return 1;";
+TEST_RESULT("External function call. Small return type 3.", testSmallReturnType3, "1");
 #endif
 
 #endif

--- a/tests/TestExternalCall.cpp
+++ b/tests/TestExternalCall.cpp
@@ -641,6 +641,39 @@ const char	*testExternalCallG9 =
 Zomg z; z.x = -1; z.y = -2; z.z = -3;\r\n\
 return Call(z);";
 TEST_RESULT("External function call. { long; float; float; } in argument.", testExternalCallG9, "1");
+
+struct TestExtG10FooSub{ int a; int b; int c; };
+struct TestExtG10Foo{ TestExtG10FooSub a; float b; };
+int TestExtG10(TestExtG10Foo x)
+{
+	return x.a.a == -1 && x.a.b == -2 && x.a.c == -3 && x.b == -4.0f;
+}
+
+LOAD_MODULE_BIND(test_extG10, "test.extG10", "class ZomgSub{ int x, y, z; } class Zomg{ ZomgSub x; float y; } int Call(Zomg a);")
+{
+	nullcBindModuleFunction("test.extG10", (void (*)())TestExtG10, "Call", 0);
+}
+const char	*testExternalCallG10 =
+"import test.extG10;\r\n\
+Zomg z; z.x.x = -1; z.x.y = -2; z.x.z = -3; z.y = -4;\r\n\
+return Call(z);";
+TEST_RESULT("External function call. { { int; int; int; }; float; } in argument.", testExternalCallG10, "1");
+
+struct TestExtG11Foo{ NULLCArray a; };
+int TestExtG11(TestExtG11Foo x)
+{
+	return x.a.len == 2 && ((int*)x.a.ptr)[0] == 1 && ((int*)x.a.ptr)[1] == 2;
+}
+
+LOAD_MODULE_BIND(test_extG11, "test.extG11", "class Zomg{ int[] x; } int Call(Zomg a);")
+{
+	nullcBindModuleFunction("test.extG11", (void (*)())TestExtG11, "Call", 0);
+}
+const char	*testExternalCallG11 =
+"import test.extG11;\r\n\
+Zomg z; z.x = { 1, 2 };\r\n\
+return Call(z);";
+TEST_RESULT("External function call. { int[]; } in argument.", testExternalCallG11, "1");
 #endif
 
 LOAD_MODULE_BIND(test_extG2b, "test.extG2b", "class Zomg{ char x; int y; } Zomg Call(Zomg a);")

--- a/tests/TestExternalCall.cpp
+++ b/tests/TestExternalCall.cpp
@@ -4,7 +4,7 @@
 
 #include <stdint.h>
 
-#if defined(_M_X64) && !defined(_WIN64)
+#if defined(_M_X64) && !defined(_WIN64) && !defined(NULLC_USE_DYNCALL)
 	#define AMD64_UNIMPLEMENTED_CALLS_20150827
 #endif
 


### PR DESCRIPTION
This branch fixes various problems with external function calls:
* Adds support for 1-16 byte POD structures containing floating-point data as arguments and return values on x64 linux
* Adds support for empty POD structures as return values on x86/x64 linux and windows
* Fixes problems when compiler optimization is enabled on x86 linux
* Adds structure arguments and return values support to dyncall library on x86/x64 linux