### PR TITLE
Fix various compilation warnings produced by newer compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@
 config=debug
 check=none
 
-REG_CFLAGS=-g -Wall -Wextra
-COMP_CFLAGS=-g -Wall -Wextra -D NULLC_NO_EXECUTOR
-DYNCALL_FLAGS=-g -Wall -Wextra
+WARNINGFLAGS = -Wall -Wextra -Wno-unknown-warning-option -Wno-class-memaccess
+
+REG_CFLAGS=-g $(WARNINGFLAGS)
+COMP_CFLAGS=-g $(WARNINGFLAGS) -DNULLC_NO_EXECUTOR
+DYNCALL_FLAGS=-g -Wall -Wextra -Wno-unknown-warning-option -Wno-cast-function-type -Wno-bad-function-cast
 STDLIB_FLAGS=-lstdc++ -lm
 FUZZ_FLAGS=
 ALIGN_FLAGS=
@@ -43,7 +45,7 @@ ifeq ($(check),fuzz)
 endif
 
 ifeq ($(CXX),clang)
-	ALIGN_FLAGS += -mllvm -align-all-nofallthru-blocks=4
+	ALIGN_FLAGS +=-mllvm -align-all-nofallthru-blocks=4
 endif
 
 LIB_SOURCES = \
@@ -147,16 +149,16 @@ DYNCALL_TARGETS = \
   temp/dyncall_s/dyncall_call.o
 
 all: temp/.dummy temp/compiler/.dummy temp/lib/.dummy temp/tests/.dummy temp/testrun/.dummy \
-    bin/nullcl bin/TestRun bin/nullc_exec bin/nullclib
+	bin/nullcl bin/TestRun bin/nullc_exec bin/nullclib
 
 ifeq ($(config),coverage)
 test: temp/.dummy temp/compiler/.dummy temp/lib/.dummy temp/tests/.dummy temp/testrun/.dummy \
-    bin/nullcl bin/TestRun bin/nullc_exec bin/nullclib
+	bin/nullcl bin/TestRun bin/nullc_exec bin/nullclib
 	./bin/TestRun -v -o -t
 	gcov -o temp NULLC/BinaryCache.cpp NULLC/Bytecode.cpp NULLC/Compiler.cpp NULLC/Executor_Common.cpp NULLC/Executor.cpp NULLC/ExpressionEval.cpp NULLC/ExpressionGraph.cpp NULLC/ExpressionTranslate.cpp NULLC/ExpressionTree.cpp NULLC/InstructionTreeLlvm.cpp NULLC/InstructionTreeVm.cpp NULLC/InstructionTreeVmCommon.cpp NULLC/InstructionTreeVmEval.cpp NULLC/InstructionTreeVmGraph.cpp NULLC/InstructionTreeVmLower.cpp NULLC/InstructionTreeVmLowerGraph.cpp NULLC/Lexer.cpp NULLC/Linker.cpp NULLC/nullc.cpp NULLC/ParseGraph.cpp NULLC/ParseTree.cpp NULLC/stdafx.cpp NULLC/StdLib.cpp NULLC/StrAlgo.cpp NULLC/TypeTree.cpp
 else
 test: temp/.dummy temp/compiler/.dummy temp/lib/.dummy temp/tests/.dummy temp/testrun/.dummy \
-    bin/nullcl bin/TestRun bin/nullc_exec bin/nullclib
+	bin/nullcl bin/TestRun bin/nullc_exec bin/nullclib
 	./bin/TestRun
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 config=debug
 check=none
 
-WARNINGFLAGS = -Wall -Wextra -Wno-unknown-warning-option -Wno-class-memaccess
+WARNINGFLAGS = -Wall -Wextra
 
 REG_CFLAGS=-g $(WARNINGFLAGS)
 COMP_CFLAGS=-g $(WARNINGFLAGS) -DNULLC_NO_EXECUTOR

--- a/NULLC/Allocator.h
+++ b/NULLC/Allocator.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "stdafx.h"
-#include "Array.h"
-#include "Pool.h"
 
 struct Allocator
 {

--- a/NULLC/Allocator.h
+++ b/NULLC/Allocator.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef NULLC_ALLOCATOR_H
-#define NULLC_ALLOCATOR_H
 
 #include "stdafx.h"
 #include "Array.h"
@@ -218,5 +216,3 @@ private:
 	void operator =(GrowingAllocatorRef &r);
 	GrowingAllocatorRef(GrowingAllocatorRef &r);
 };
-
-#endif

--- a/NULLC/Array.h
+++ b/NULLC/Array.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef NULLC_ARRAY_H
-#define NULLC_ARRAY_H
 
 #include "Allocator.h"
 
@@ -600,5 +598,3 @@ struct VectorView
 
 	T *data;
 };
-
-#endif

--- a/NULLC/Array.h
+++ b/NULLC/Array.h
@@ -28,7 +28,7 @@ public:
 		assert(data);
 
 		if(zeroNewMemory)
-			memset(data, 0, reserved * sizeof(T));
+			NULLC::fillMemory(data, 0, reserved * sizeof(T));
 
 		max = reserved;
 		count = 0;
@@ -167,10 +167,10 @@ public:
 		assert(newData);
 
 		if(zeroNewMemory)
-			memset(newData, 0, newSize * sizeof(T));
+			NULLC::fillMemory(newData, 0, newSize * sizeof(T));
 
 		if(data)
-			memcpy(newData, data, max * sizeof(T));
+			NULLC::copyMemory(newData, data, max * sizeof(T));
 
 		data = newData;
 		max = newSize;
@@ -589,7 +589,7 @@ struct VectorView
 	{
 		assert(count + amount <= capacity);
 
-		memcpy(data + count, elems, amount * sizeof(T));
+		NULLC::copyMemory(data + count, elems, amount * sizeof(T));
 		count += amount;
 	}
 

--- a/NULLC/BinaryCache.cpp
+++ b/NULLC/BinaryCache.cpp
@@ -1,6 +1,7 @@
 #include "BinaryCache.h"
 
 #include "Lexer.h"
+#include "StrAlgo.h"
 
 namespace BinaryCache
 {

--- a/NULLC/Bytecode.h
+++ b/NULLC/Bytecode.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef NULLC_BYTECODE_H
-#define NULLC_BYTECODE_H
 
 #include "nullcdef.h"
 
@@ -337,5 +335,3 @@ char*				FindSymbols(ByteCode *code);
 char*				FindSource(ByteCode *code);
 unsigned*			FindRegVmConstants(ByteCode *code);
 unsigned char*		FindRegVmRegKillInfo(ByteCode *code);
-
-#endif

--- a/NULLC/CodeGenRegVm_X86.h
+++ b/NULLC/CodeGenRegVm_X86.h
@@ -123,15 +123,15 @@ struct CodeGenRegVmStateContext
 	double (*x64ModdWrap)(double lhs, double rhs);
 	long long (*x64PowlWrap)(long long lhs, long long rhs);
 
-	void (*x86PowWrap)(CodeGenRegVmStateContext *vmState, unsigned cmdValueA, unsigned cmdValueB);
-	void (*x86PowdWrap)(CodeGenRegVmStateContext *vmState, unsigned cmdValueA, unsigned cmdValueB);
-	void (*x86ModdWrap)(CodeGenRegVmStateContext *vmState, unsigned cmdValueA, unsigned cmdValueB);
+	void (*x86PowWrap)(CodeGenRegVmStateContext *vmState, unsigned cmdValueABC, unsigned cmdArgument);
+	void (*x86PowdWrap)(CodeGenRegVmStateContext *vmState, unsigned cmdValueABC, unsigned cmdArgument);
+	void (*x86ModdWrap)(CodeGenRegVmStateContext *vmState, unsigned cmdValueABC, unsigned cmdArgument);
 	long long (*x86MullWrap)(long long lhs, long long rhs);
 	long long (*x86DivlWrap)(long long lhs, long long rhs);
 	long long (*x86PowlWrap)(long long lhs, long long rhs);
 	long long (*x86ModlWrap)(long long lhs, long long rhs);
-	void (*x86LtodWrap)(CodeGenRegVmStateContext *vmState, unsigned cmdValueA, unsigned cmdValueB);
-	void (*x86DtolWrap)(CodeGenRegVmStateContext *vmState, unsigned cmdValueA, unsigned cmdValueB);
+	void (*x86LtodWrap)(CodeGenRegVmStateContext *vmState, unsigned cmdValueAC);
+	void (*x86DtolWrap)(CodeGenRegVmStateContext *vmState, unsigned cmdValueAC);
 	long long (*x86ShllWrap)(long long lhs, long long rhs);
 	long long (*x86ShrlWrap)(long long lhs, long long rhs);
 

--- a/NULLC/DenseMap.h
+++ b/NULLC/DenseMap.h
@@ -24,7 +24,7 @@ public:
 
 		data = storage;
 
-		memset(data, 0, sizeof(Node) * bucketCount);
+		NULLC::fillMemory(data, 0, sizeof(Node) * bucketCount);
 	}
 
 	~SmallDenseMap()
@@ -50,7 +50,7 @@ public:
 	{
 		count = 0;
 
-		memset(data, 0, sizeof(Node) * bucketCount);
+		NULLC::fillMemory(data, 0, sizeof(Node) * bucketCount);
 	}
 
 	void insert(const Key& key, const Value& value)
@@ -125,7 +125,7 @@ public:
 		else
 			data = (Node*)NULLC::alloc(sizeof(Node) * bucketCount);
 
-		memset(data, 0, sizeof(Node) * bucketCount);
+		NULLC::fillMemory(data, 0, sizeof(Node) * bucketCount);
 
 		count = 0;
 
@@ -182,7 +182,7 @@ public:
 
 		data = storage;
 
-		memset(data, 0, sizeof(Key) * bucketCount);
+		NULLC::fillMemory(data, 0, sizeof(Key) * bucketCount);
 	}
 
 	~SmallDenseSet()
@@ -208,7 +208,7 @@ public:
 	{
 		count = 0;
 
-		memset(data, 0, sizeof(Key) * bucketCount);
+		NULLC::fillMemory(data, 0, sizeof(Key) * bucketCount);
 	}
 
 	void insert(const Key& key)
@@ -279,7 +279,7 @@ public:
 		else
 			data = (Key*)NULLC::alloc(sizeof(Key) * bucketCount);
 
-		memset(data, 0, sizeof(Key) * bucketCount);
+		NULLC::fillMemory(data, 0, sizeof(Key) * bucketCount);
 
 		count = 0;
 
@@ -377,7 +377,7 @@ public:
 		count = 0;
 
 		data = (Node*)allocator->alloc(sizeof(Node) * bucketCount);
-		memset(data, 0, sizeof(Node) * bucketCount);
+		NULLC::fillMemory(data, 0, sizeof(Node) * bucketCount);
 	}
 
 	~DirectChainedMap()
@@ -387,7 +387,7 @@ public:
 
 	void clear()
 	{
-		memset(data, 0, sizeof(Node) * bucketCount);
+		NULLC::fillMemory(data, 0, sizeof(Node) * bucketCount);
 
 		count = 0;
 	}
@@ -569,7 +569,7 @@ public:
 		count = 0;
 
 		data = (Node*)allocator->alloc(sizeof(Node) * bucketCount);
-		memset(data, 0, sizeof(Node) * bucketCount);
+		NULLC::fillMemory(data, 0, sizeof(Node) * bucketCount);
 
 		for(unsigned i = 0; i < oldBucketCount; i++)
 		{

--- a/NULLC/Executor_Common.cpp
+++ b/NULLC/Executor_Common.cpp
@@ -7,6 +7,7 @@
 #include "Executor_LLVM.h"
 #include "Executor_RegVm.h"
 #include "Linker.h"
+#include "StrAlgo.h"
 
 #if !defined(NULLC_NO_RAW_EXTERNAL_CALL)
 #define dcAllocMem NULLC::alloc

--- a/NULLC/Executor_LLVM.cpp
+++ b/NULLC/Executor_LLVM.cpp
@@ -3,6 +3,7 @@
 #include "nullc.h"
 #include "Linker.h"
 #include "StdLib.h"
+#include "StrAlgo.h"
 
 #ifdef NULLC_LLVM_SUPPORT
 

--- a/NULLC/Executor_LLVM.cpp
+++ b/NULLC/Executor_LLVM.cpp
@@ -316,7 +316,7 @@ bool ExecutorLLVM::TranslateToNative()
 	{
 		char buf[32];
 
-		sprintf(buf, "module_%d", i);
+		NULLC::SafeSprintf(buf, 32, "module_%d", i);
 
 		// Load module code
 		LLVMMemoryBufferRef buffer = LLVMCreateMemoryBufferWithMemoryRange(&exLinker->llvmModuleCodes[offset], exLinker->llvmModuleSizes[i], buf, false);
@@ -331,7 +331,7 @@ bool ExecutorLLVM::TranslateToNative()
 		// Change global code function name, because every module has one
 		LLVMValueRef entryFunction = LLVMGetNamedFunction(moduleData, "__llvmEntry");
 		
-		sprintf(buf, "__llvmEntry_%d", i);
+		NULLC::SafeSprintf(buf, 32, "__llvmEntry_%d", i);
 		LLVMSetValueName2(entryFunction, buf, strlen(buf));
 
 		// TODO: change the type index constant values
@@ -341,7 +341,7 @@ bool ExecutorLLVM::TranslateToNative()
 		for(unsigned k = 0; k < typeCount; k++)
 		{
 			char buf[32];
-			sprintf(buf, "^type_index_%d", k);
+			NULLC::SafeSprintf(buf, 32, "^type_index_%d", k);
 
 			if(llvm::GlobalVariable *typeIndexValue = module->getGlobalVariable(buf, true))
 				typeIndexValue->setInitializer(llvm::ConstantInt::get(llvm::Type::getInt32Ty(getContext()), llvm::APInt(32, uint64_t(typeRemap[k]), false)));
@@ -354,7 +354,7 @@ bool ExecutorLLVM::TranslateToNative()
 		for(unsigned k = 0; k < functionCount; k++)
 		{
 			char buf[32];
-			sprintf(buf, "^func_index_%d", k);
+			NULLC::SafeSprintf(buf, 32, "^func_index_%d", k);
 
 			if(llvm::GlobalVariable *funcIndexValue = module->getGlobalVariable(buf, true))
 				funcIndexValue->setInitializer(llvm::ConstantInt::get(llvm::Type::getInt32Ty(getContext()), llvm::APInt(32, uint64_t(funcRemap[k]), false)));
@@ -569,7 +569,7 @@ bool ExecutorLLVM::Run(unsigned int functionID, const char *arguments)
 	for(unsigned i = 0; i < exLinker->llvmModuleSizes.size(); i++)
 	{
 		char buf[32];
-		sprintf(buf, "__llvmEntry_%d", i);
+		NULLC::SafeSprintf(buf, 32, "__llvmEntry_%d", i);
 
 		LLVMValueRef function = LLVMGetNamedFunction(ctx->module, buf);
 

--- a/NULLC/Executor_RegVm.cpp
+++ b/NULLC/Executor_RegVm.cpp
@@ -6,6 +6,7 @@
 #include "nullc_debug.h"
 #include "Linker.h"
 #include "StdLib.h"
+#include "StrAlgo.h"
 
 #if defined(_MSC_VER)
 #pragma warning(disable: 4702) // unreachable code

--- a/NULLC/Executor_X86.cpp
+++ b/NULLC/Executor_X86.cpp
@@ -2001,7 +2001,8 @@ void ExecutorX86::SaveListing(OutputContext &output)
 {
 	TRACE_SCOPE("x86", "SaveListing");
 
-	char instBuf[128];
+	const unsigned instBufSize = 128;
+	char instBuf[instBufSize];
 
 	for(unsigned i = 0; i < instList.size(); i++)
 	{
@@ -2080,7 +2081,7 @@ void ExecutorX86::SaveListing(OutputContext &output)
 			output.Print('\n');
 		}
 
-		inst.Decode(vmState, instBuf);
+		inst.Decode(vmState, instBuf, instBufSize);
 
 		output.Print(instBuf);
 		output.Print('\n');

--- a/NULLC/Executor_X86.cpp
+++ b/NULLC/Executor_X86.cpp
@@ -14,6 +14,7 @@
 #include "StdLib.h"
 #include "InstructionTreeRegVmLowerGraph.h"
 #include "Trace.h"
+#include "StrAlgo.h"
 
 #if !defined(NULLC_NO_RAW_EXTERNAL_CALL)
 #define dcAllocMem NULLC::alloc

--- a/NULLC/Executor_X86.h
+++ b/NULLC/Executor_X86.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "stdafx.h"
-#include "InstructionTreeRegVm.h"
+
+#include "Array.h"
 #include "CodeGenRegVm_X86.h"
+#include "InstructionTreeRegVm.h"
 
 #if !defined(NULLC_NO_RAW_EXTERNAL_CALL)
 typedef struct DCCallVM_ DCCallVM;

--- a/NULLC/ExpressionTree.cpp
+++ b/NULLC/ExpressionTree.cpp
@@ -5548,16 +5548,18 @@ ExprBase* AnalyzeArrayIndex(ExpressionContext &ctx, SynTypeArray *syntax)
 
 InplaceStr GetTemporaryFunctionName(ExpressionContext &ctx)
 {
-	char *name = (char*)ctx.allocator->alloc(16);
-	sprintf(name, "$func%d", ctx.unnamedFuncCount++);
+	unsigned length = 16;
+	char *name = (char*)ctx.allocator->alloc(length);
+	NULLC::SafeSprintf(name, length, "$func%d", ctx.unnamedFuncCount++);
 
 	return InplaceStr(name);
 }
 
 InplaceStr GetDefaultArgumentWrapperFunctionName(ExpressionContext &ctx, FunctionData *function, InplaceStr argumentName)
 {
-	char *name = (char*)ctx.allocator->alloc(function->name->name.length() + argumentName.length() + 16);
-	sprintf(name, "%.*s_%u_%.*s$", FMT_ISTR(function->name->name), function->type->nameHash, FMT_ISTR(argumentName));
+	unsigned length = function->name->name.length() + argumentName.length() + 16;
+	char *name = (char*)ctx.allocator->alloc(length);
+	NULLC::SafeSprintf(name, length, "%.*s_%u_%.*s$", FMT_ISTR(function->name->name), function->type->nameHash, FMT_ISTR(argumentName));
 
 	return InplaceStr(name);
 }
@@ -9473,9 +9475,10 @@ ExprBase* AnalyzeShortFunctionDefinition(ExpressionContext &ctx, SynShortFunctio
 			if(isType<TypeError>(type))
 				return NULL;
 
-			char *name = (char*)ctx.allocator->alloc(param->name->name.length() + 2);
+			unsigned length = param->name->name.length() + 2;
+			char *name = (char*)ctx.allocator->alloc(length);
 
-			sprintf(name, "%.*s$", FMT_ISTR(param->name->name));
+			NULLC::SafeSprintf(name, length, "%.*s$", FMT_ISTR(param->name->name));
 
 			if(expected->type->isGeneric)
 			{
@@ -9579,9 +9582,10 @@ ExprBase* AnalyzeShortFunctionDefinition(ExpressionContext &ctx, SynShortFunctio
 		if(!conflict)
 			ctx.AddVariable(variable, true);
 
-		char *name = (char*)ctx.allocator->alloc(el->name->name.length() + 2);
+		unsigned length = el->name->name.length() + 2;
+		char *name = (char*)ctx.allocator->alloc(length);
 
-		sprintf(name, "%.*s$", FMT_ISTR(el->name->name));
+		NULLC::SafeSprintf(name, length, "%.*s$", FMT_ISTR(el->name->name));
 
 		ExprBase *access = CreateVariableAccess(ctx, syntax, IntrusiveList<SynIdentifier>(), InplaceStr(name), false);
 
@@ -9878,8 +9882,9 @@ InplaceStr GetTypeDefaultConstructorName(ExpressionContext &ctx, TypeClass *clas
 {
 	InplaceStr baseName(GetTypeConstructorName(classType));
 
-	char *name = (char*)ctx.allocator->alloc(baseName.length() + 2);
-	sprintf(name, "%.*s$", FMT_ISTR(baseName));
+	unsigned length = baseName.length() + 2;
+	char *name = (char*)ctx.allocator->alloc(length);
+	NULLC::SafeSprintf(name, length, "%.*s$", FMT_ISTR(baseName));
 
 	return InplaceStr(name);
 }

--- a/NULLC/InstructionTreeVm.h
+++ b/NULLC/InstructionTreeVm.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #include "stdafx.h"
+
+#include "Array.h"
 #include "IntrusiveList.h"
+#include "StrAlgo.h"
+
+struct Allocator;
 
 struct SynBase;
 

--- a/NULLC/InstructionTreeVmEval.cpp
+++ b/NULLC/InstructionTreeVmEval.cpp
@@ -2282,7 +2282,7 @@ VmConstant* EvaluateKnownExternalFunction(InstructionVMEvalContext &ctx, Functio
 			return NULL;
 
 		char buf[32];
-		sprintf(buf, "%d", value->iValue);
+		NULLC::SafeSprintf(buf, 32, "%d", value->iValue);
 
 		unsigned length = unsigned(strlen(buf) + 1);
 
@@ -2307,7 +2307,7 @@ VmConstant* EvaluateKnownExternalFunction(InstructionVMEvalContext &ctx, Functio
 			return NULL;
 
 		char buf[32];
-		sprintf(buf, "%lld", value->lValue);
+		NULLC::SafeSprintf(buf, 32, "%lld", value->lValue);
 
 		unsigned length = unsigned(strlen(buf) + 1);
 

--- a/NULLC/Instruction_X86.cpp
+++ b/NULLC/Instruction_X86.cpp
@@ -1,6 +1,7 @@
 #include "Instruction_X86.h"
 
 #include "CodeGenRegVm_X86.h"
+#include "StrAlgo.h"
 
 namespace
 {

--- a/NULLC/Instruction_X86.cpp
+++ b/NULLC/Instruction_X86.cpp
@@ -46,7 +46,7 @@ namespace
 	};
 }
 
-int x86Argument::Decode(CodeGenRegVmStateContext &ctx, char *buf, bool x64, bool useMmWord, bool skipSize)
+int x86Argument::Decode(CodeGenRegVmStateContext &ctx, char *buf, unsigned bufSize, bool x64, bool useMmWord, bool skipSize)
 {
 	char *curr = buf;
 
@@ -54,28 +54,28 @@ int x86Argument::Decode(CodeGenRegVmStateContext &ctx, char *buf, bool x64, bool
 	{
 		if(ctx.vsAsmStyle)
 		{
-			curr += sprintf(curr, "%x%s", num, num > 9 ? "h" : "");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "%x%s", num, num > 9 ? "h" : "");
 		}
 		else
 		{
 			if(uintptr_t(num) == uintptr_t(&ctx.callInstructionPos))
-				curr += sprintf(curr, "&ctx.callInstructionPos");
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.callInstructionPos");
 			else if(uintptr_t(num) == uintptr_t(&ctx.dataStackTop))
-				curr += sprintf(curr, "&ctx.dataStackTop");
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.dataStackTop");
 			else if(uintptr_t(num) == uintptr_t(&ctx.callStackTop))
-				curr += sprintf(curr, "&ctx.callStackTop");
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.callStackTop");
 			else if(uintptr_t(num) == uintptr_t(&ctx.regFileLastTop))
-				curr += sprintf(curr, "&ctx.regFileLastTop");
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.regFileLastTop");
 			else if(uintptr_t(num) == uintptr_t(&ctx.regFileLastPtr))
-				curr += sprintf(curr, "&ctx.regFileLastPtr");
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.regFileLastPtr");
 			else if(uintptr_t(num) == uintptr_t(ctx.dataStackBase))
-				curr += sprintf(curr, "ctx.dataStackBase");
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "ctx.dataStackBase");
 			else if(uintptr_t(num) == uintptr_t(ctx.ctx->exRegVmConstants))
-				curr += sprintf(curr, "ctx.exRegVmConstants");
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "ctx.exRegVmConstants");
 			else if(uintptr_t(num) == uintptr_t(&ctx))
-				curr += sprintf(curr, "&ctx");
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx");
 			else
-				curr += sprintf(curr, "%d", num);
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "%d", num);
 		}
 	}
 	else if(type == argReg)
@@ -90,11 +90,11 @@ int x86Argument::Decode(CodeGenRegVmStateContext &ctx, char *buf, bool x64, bool
 	}
 	else if(type == argLabel)
 	{
-		curr += sprintf(curr, "'0x%x'", labelID);
+		curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "'0x%x'", labelID);
 	}
 	else if(type == argPtrLabel)
 	{
-		curr += sprintf(curr, "['0x%x'+%d]", labelID, ptrNum);
+		curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "['0x%x'+%d]", labelID, ptrNum);
 	}
 	else if(type == argPtr)
 	{
@@ -126,17 +126,17 @@ int x86Argument::Decode(CodeGenRegVmStateContext &ctx, char *buf, bool x64, bool
 			}
 
 			if(ptrMult > 1)
-				curr += sprintf(curr, "*%d", ptrMult);
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "*%d", ptrMult);
 		}
 
 		if(ptrBase != rNONE)
 		{
 			if(ctx.vsAsmStyle)
-				curr += sprintf(curr, "%s", (x64 ? x64RegText : x86RegText)[ptrBase]);
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "%s", (x64 ? x64RegText : x86RegText)[ptrBase]);
 			else if(ptrIndex != rNONE)
-				curr += sprintf(curr, " + %s", (x64 ? x64RegText : x86RegText)[ptrBase]);
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), " + %s", (x64 ? x64RegText : x86RegText)[ptrBase]);
 			else
-				curr += sprintf(curr, "%s", (x64 ? x64RegText : x86RegText)[ptrBase]);
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "%s", (x64 ? x64RegText : x86RegText)[ptrBase]);
 		}
 
 		if(ctx.vsAsmStyle)
@@ -151,43 +151,43 @@ int x86Argument::Decode(CodeGenRegVmStateContext &ctx, char *buf, bool x64, bool
 			}
 
 			if(ptrMult > 1)
-				curr += sprintf(curr, "*%d", ptrMult);
+				curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "*%d", ptrMult);
 		}
 
 		if(ptrIndex == rNONE && ptrBase == rNONE && ctx.vsAsmStyle)
-			curr += sprintf(curr, "%x%s", ptrNum, ptrNum > 9 ? "h" : "");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "%x%s", ptrNum, ptrNum > 9 ? "h" : "");
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) >= uintptr_t(ctx.tempStackArrayBase) && uintptr_t(ptrNum) < uintptr_t(ctx.tempStackArrayEnd))
-			curr += sprintf(curr, "temp+%u", unsigned(ptrNum - uintptr_t(ctx.tempStackArrayBase)));
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "temp+%u", unsigned(ptrNum - uintptr_t(ctx.tempStackArrayBase)));
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) >= uintptr_t(ctx.dataStackBase) && uintptr_t(ptrNum) < uintptr_t(ctx.dataStackEnd))
-			curr += sprintf(curr, "globals+%u", unsigned(ptrNum - uintptr_t(ctx.dataStackBase)));
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "globals+%u", unsigned(ptrNum - uintptr_t(ctx.dataStackBase)));
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) >= uintptr_t(ctx.ctx->exRegVmConstants) && uintptr_t(ptrNum) < uintptr_t(ctx.ctx->exRegVmConstantsEnd))
-			curr += sprintf(curr, "constants+%u", unsigned(ptrNum - uintptr_t(ctx.ctx->exRegVmConstants)));
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "constants+%u", unsigned(ptrNum - uintptr_t(ctx.ctx->exRegVmConstants)));
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) == uintptr_t(&ctx.callInstructionPos))
-			curr += sprintf(curr, "&ctx.callInstructionPos");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.callInstructionPos");
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) == uintptr_t(&ctx.dataStackTop))
-			curr += sprintf(curr, "&ctx.dataStackTop");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.dataStackTop");
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) == uintptr_t(&ctx.callStackTop))
-			curr += sprintf(curr, "&ctx.callStackTop");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.callStackTop");
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) == uintptr_t(&ctx.regFileLastTop))
-			curr += sprintf(curr, "&ctx.regFileLastTop");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.regFileLastTop");
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) == uintptr_t(&ctx.regFileLastPtr))
-			curr += sprintf(curr, "&ctx.regFileLastPtr");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.regFileLastPtr");
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) == uintptr_t(&ctx.callWrap))
-			curr += sprintf(curr, "&ctx.callWrap");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.callWrap");
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) == uintptr_t(&ctx.checkedReturnWrap))
-			curr += sprintf(curr, "&ctx.checkedReturnWrap");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.checkedReturnWrap");
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) == uintptr_t(&ctx.convertPtrWrap))
-			curr += sprintf(curr, "&ctx.convertPtrWrap");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.convertPtrWrap");
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) == uintptr_t(&ctx.errorOutOfBoundsWrap))
-			curr += sprintf(curr, "&ctx.errorOutOfBoundsWrap");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.errorOutOfBoundsWrap");
 		else if(ptrIndex == rNONE && ptrBase == rNONE && uintptr_t(ptrNum) == uintptr_t(&ctx.errorNoReturnWrap))
-			curr += sprintf(curr, "&ctx.errorNoReturnWrap");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.errorNoReturnWrap");
 		else if(ptrIndex == rNONE && ptrBase == rNONE)
-			curr += sprintf(curr, "%d", ptrNum);
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "%d", ptrNum);
 		else if(ptrNum != 0 && ctx.vsAsmStyle)
-			curr += sprintf(curr, "+%x%s", ptrNum, ptrNum > 9 ? "h" : "");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "+%x%s", ptrNum, ptrNum > 9 ? "h" : "");
 		else if(ptrNum != 0)
-			curr += sprintf(curr, "%+d", ptrNum);
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "%+d", ptrNum);
 
 		*curr++ = ']';
 		*curr = 0;
@@ -195,21 +195,22 @@ int x86Argument::Decode(CodeGenRegVmStateContext &ctx, char *buf, bool x64, bool
 	else if(type == argImm64)
 	{
 		if(imm64Arg == uintptr_t(&ctx))
-			curr += sprintf(curr, "&ctx");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx");
 		else if(imm64Arg == uintptr_t(&ctx.tempStackArrayBase))
-			curr += sprintf(curr, "&ctx.tempStackArrayBase");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "&ctx.tempStackArrayBase");
 		else if(imm64Arg == uintptr_t(ctx.tempStackArrayBase))
-			curr += sprintf(curr, "ctx.tempStackArrayBase");
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "ctx.tempStackArrayBase");
 		else if(ctx.vsAsmStyle)
-			curr += sprintf(curr, "%llXh", (unsigned long long)imm64Arg);
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "%llXh", (unsigned long long)imm64Arg);
 		else
-			curr += sprintf(curr, "%lld", (long long)imm64Arg);
+			curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "%lld", (long long)imm64Arg);
 	}
 
-	return (int)(curr - buf);
+	assert(buf + bufSize <= curr);
+	return int(curr - buf);
 }
 
-int	x86Instruction::Decode(CodeGenRegVmStateContext &ctx, char *buf)
+int	x86Instruction::Decode(CodeGenRegVmStateContext &ctx, char *buf, unsigned bufSize)
 {
 	char *curr = buf;
 
@@ -218,7 +219,7 @@ int	x86Instruction::Decode(CodeGenRegVmStateContext &ctx, char *buf)
 
 	if(name == o_label)
 	{
-		curr += sprintf(curr, "0x%p:", (void*)(intptr_t)labelID);
+		curr += NULLC::SafeSprintf(curr, bufSize - unsigned(curr - buf), "0x%p:", (void*)(intptr_t)labelID);
 	}
 	else if(name == o_other)
 	{
@@ -249,7 +250,7 @@ int	x86Instruction::Decode(CodeGenRegVmStateContext &ctx, char *buf)
 			bool usex64 = name >= o_mov64 || name == o_movsxd || ((argA.type == x86Argument::argPtr || name == o_call || name == o_push || name == o_pop) && sizeof(void*) == 8) || (argB.type == x86Argument::argPtr && argB.ptrSize == sQWORD && name != o_cvttsd2si);
 			bool useMmWord = ctx.vsAsmStyle && argB.type == x86Argument::argXmmReg;
 
-			curr += argA.Decode(ctx, curr, usex64, useMmWord, name == o_lea);
+			curr += argA.Decode(ctx, curr, bufSize, usex64, useMmWord, name == o_lea);
 		}
 		if(argB.type != x86Argument::argNone)
 		{
@@ -261,7 +262,7 @@ int	x86Instruction::Decode(CodeGenRegVmStateContext &ctx, char *buf)
 			bool usex64 = name >= o_mov64 || (argB.type == x86Argument::argPtr && sizeof(void*) == 8) || name == o_movsxd || (argA.type == x86Argument::argPtr && argA.ptrSize == sQWORD);
 			bool useMmWord = ctx.vsAsmStyle && (argA.type == x86Argument::argXmmReg || name == o_cvttsd2si || name == o_cvttsd2si64);
 
-			curr += argB.Decode(ctx, curr, usex64, useMmWord, name == o_lea);
+			curr += argB.Decode(ctx, curr, bufSize, usex64, useMmWord, name == o_lea);
 		}
 	}
 
@@ -272,5 +273,6 @@ int	x86Instruction::Decode(CodeGenRegVmStateContext &ctx, char *buf)
 		*curr = 0;
 	}
 
-	return (int)(curr-buf);
+	assert(buf + bufSize <= curr);
+	return int(curr - buf);
 }

--- a/NULLC/Instruction_X86.h
+++ b/NULLC/Instruction_X86.h
@@ -200,90 +200,131 @@ struct x86Argument
 	// no argument
 	x86Argument()
 	{
-		Empty();
+		this->type = argNone;
+		this->imm64Arg = 0;
+		this->ptrBase = rNONE;
+		this->ptrIndex = rNONE;
+		this->ptrMult = 0;
+		this->ptrNum = 0;
 	}
 
 	// immediate number
-	explicit x86Argument(int Num)
+	explicit x86Argument(int num)
 	{
-		Empty();
-		type = argNumber;
-		num = Num;
+		this->type = argNumber;
+		this->num = num;
+		this->ptrBase = rNONE;
+		this->ptrIndex = rNONE;
+		this->ptrMult = 0;
+		this->ptrNum = 0;
 	}
-	explicit x86Argument(unsigned Num)
+
+	explicit x86Argument(unsigned num)
 	{
-		Empty();
-		type = argNumber;
-		num = Num;
+		this->type = argNumber;
+		this->num = num;
+		this->ptrBase = rNONE;
+		this->ptrIndex = rNONE;
+		this->ptrMult = 0;
+		this->ptrNum = 0;
 	}
+
 	// register
-	explicit x86Argument(x86Reg Register)
+	explicit x86Argument(x86Reg reg)
 	{
-		Empty();
-		type = argReg;
-		reg = Register;
+		this->type = argReg;
+		this->reg = reg;
+		this->ptrBase = rNONE;
+		this->ptrIndex = rNONE;
+		this->ptrMult = 0;
+		this->ptrNum = 0;
 	}
+
 	// sse register
 	explicit x86Argument(x86XmmReg xmmReg)
 	{
-		Empty();
-		type = argXmmReg;
-		xmmArg = xmmReg;
-	}
-	// size [num]
-	x86Argument(x86Size Size, unsigned int Num)
-	{
-		Empty();
-		type = argPtr;
-		ptrSize = Size; ptrMult = 1; ptrNum = Num;
-	}
-	// size [register + num]
-	x86Argument(x86Size Size, x86Reg RegA, unsigned int Num)
-	{
-		Empty();
-		type = argPtr;
-		ptrSize = Size; ptrBase = RegA; ptrMult = 1; ptrNum = Num;
-	}
-	// size [register + register + num]
-	x86Argument(x86Size Size, x86Reg RegA, x86Reg RegB, unsigned int Num)
-	{
-		Empty();
-		type = argPtr;
-		ptrSize = Size; ptrBase = RegB; ptrMult = 1; ptrIndex = RegA; ptrNum = Num;
-	}
-	// size [register * multiplier + register + num]
-	x86Argument(x86Size Size, x86Reg RegA, unsigned int Mult, x86Reg RegB, unsigned int Num)
-	{
-		Empty();
-		type = argPtr;
-		ptrSize = Size; ptrBase = RegB; ptrMult = Mult; ptrIndex = RegA; ptrNum = Num;
-	}
-	// long immediate number
-	explicit x86Argument(long long Num)
-	{
-		Empty();
-		type = argImm64;
-		imm64Arg = Num;
-	}
-	// long immediate number
-	explicit x86Argument(unsigned long long Num)
-	{
-		Empty();
-		type = argImm64;
-		imm64Arg = Num;
+		this->type = argXmmReg;
+		this->xmmArg = xmmReg;
+		this->ptrBase = rNONE;
+		this->ptrIndex = rNONE;
+		this->ptrMult = 0;
+		this->ptrNum = 0;
 	}
 
-	void Empty()
+	// size [num]
+	x86Argument(x86Size size, unsigned num)
 	{
-		memset(this, 0, sizeof(x86Argument));
+		this->type = argPtr;
+		this->ptrSize = size;
+		this->ptrBase = rNONE;
+		this->ptrIndex = rNONE;
+		this->ptrMult = 1;
+		this->ptrNum = num;
+	}
+
+	// size [register + num]
+	x86Argument(x86Size size, x86Reg regA, unsigned num)
+	{
+		this->type = argPtr;
+		this->ptrSize = size;
+		this->ptrBase = regA;
+		this->ptrIndex = rNONE;
+		this->ptrMult = 1;
+		this->ptrNum = num;
+	}
+
+	// size [register + register + num]
+	x86Argument(x86Size size, x86Reg regA, x86Reg regB, unsigned num)
+	{
+		this->type = argPtr;
+		this->ptrSize = size;
+		this->ptrBase = regB;
+		this->ptrIndex = regA;
+		this->ptrMult = 1;
+		this->ptrNum = num;
+	}
+
+	// size [register * multiplier + register + num]
+	x86Argument(x86Size size, x86Reg regA, unsigned mult, x86Reg regB, unsigned num)
+	{
+		this->type = argPtr;
+		this->ptrSize = size;
+		this->ptrBase = regB;
+		this->ptrIndex = regA;
+		this->ptrMult = mult;
+		this->ptrNum = num;
+	}
+
+	// long immediate number
+	explicit x86Argument(long long num)
+	{
+		this->type = argImm64;
+		this->imm64Arg = num;
+		this->ptrBase = rNONE;
+		this->ptrIndex = rNONE;
+		this->ptrMult = 0;
+		this->ptrNum = 0;
+	}
+
+	// long immediate number
+	explicit x86Argument(unsigned long long num)
+	{
+		this->type = argImm64;
+		this->imm64Arg = num;
+		this->ptrBase = rNONE;
+		this->ptrIndex = rNONE;
+		this->ptrMult = 0;
+		this->ptrNum = 0;
 	}
 
 	bool operator==(const x86Argument& r)
 	{
 		if(type != r.type || reg != r.reg)
 			return false;
+
 		if(ptrSize != r.ptrSize || ptrBase != r.ptrBase || ptrIndex != r.ptrIndex || ptrMult != r.ptrMult || ptrNum != r.ptrNum)
 			return false;
+
 		return true;
 	}
 
@@ -299,7 +340,8 @@ struct x86Argument
 		unsigned long long imm64Arg;		// Used only when type == argImm64
 	};
 
-	x86Reg	ptrBase, ptrIndex;
+	x86Reg	ptrBase;
+	x86Reg	ptrIndex;
 	int		ptrMult;
 	int		ptrNum;
 

--- a/NULLC/Instruction_X86.h
+++ b/NULLC/Instruction_X86.h
@@ -345,7 +345,7 @@ struct x86Argument
 	int		ptrMult;
 	int		ptrNum;
 
-	int	Decode(CodeGenRegVmStateContext &ctx, char *buf, bool x64, bool useMmWord, bool skipSize);
+	int	Decode(CodeGenRegVmStateContext &ctx, char *buf, unsigned bufSize, bool x64, bool useMmWord, bool skipSize);
 };
 
 struct x86Instruction
@@ -384,5 +384,5 @@ struct x86Instruction
 	};
 
 	// returns string length
-	int	Decode(CodeGenRegVmStateContext &ctx, char *buf);
+	int	Decode(CodeGenRegVmStateContext &ctx, char *buf, unsigned bufSize);
 };

--- a/NULLC/Lexer.h
+++ b/NULLC/Lexer.h
@@ -1,5 +1,9 @@
 #pragma once
+
 #include "stdafx.h"
+
+#include "Allocator.h"
+#include "Array.h"
 
 enum chartype
 {

--- a/NULLC/Linker.cpp
+++ b/NULLC/Linker.cpp
@@ -5,6 +5,7 @@
 #include "DenseMap.h"
 #include "InstructionTreeRegVmLowerGraph.h"
 #include "Trace.h"
+#include "StrAlgo.h"
 
 extern "C"
 {

--- a/NULLC/Linker.h
+++ b/NULLC/Linker.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef NULLC_LINKER_H
-#define NULLC_LINKER_H
 
 #include "stdafx.h"
 #include "Bytecode.h"
@@ -82,5 +80,3 @@ public:
 
 	unsigned debugOutputIndent;
 };
-
-#endif

--- a/NULLC/ParseTree.cpp
+++ b/NULLC/ParseTree.cpp
@@ -7,6 +7,7 @@
 #include "BinaryCache.h"
 #include "Bytecode.h"
 #include "Lexer.h"
+#include "Pool.h"
 #include "Trace.h"
 
 void AddErrorLocationInfo(const char *codeStart, const char *errorPos, char *errorBuf, unsigned errorBufSize);

--- a/NULLC/Pool.h
+++ b/NULLC/Pool.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef NULLC_POOL_H
-#define NULLC_POOL_H
 
 template<int chunkSize>
 class ChunkedStackPool
@@ -181,5 +179,3 @@ public:
 	MyLargeBlock	*activePages;
 	unsigned		lastNum;
 };
-
-#endif

--- a/NULLC/Pool.h
+++ b/NULLC/Pool.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "stdafx.h"
+
 template<int chunkSize>
 class ChunkedStackPool
 {

--- a/NULLC/Statistics.h
+++ b/NULLC/Statistics.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Array.h"
+#include "StrAlgo.h"
 
 struct CompilerStatistics
 {

--- a/NULLC/StdLib.cpp
+++ b/NULLC/StdLib.cpp
@@ -8,6 +8,7 @@
 #include "stdafx.h"
 #include "Pool.h"
 #include "Tree.h"
+#include "StrAlgo.h"
 
 #include "Executor_Common.h"
 #include "Linker.h"

--- a/NULLC/StrAlgo.cpp
+++ b/NULLC/StrAlgo.cpp
@@ -41,7 +41,7 @@ int	NULLC::SafeSprintf(char* dst, size_t size, const char* src, ...)
 	va_start(args, src);
 
 	int result = vsnprintf(dst, size, src, args);
-	dst[size-1] = '\0';
+	dst[size - 1] = '\0';
 
 	va_end(args);
 

--- a/NULLC/StrAlgo.h
+++ b/NULLC/StrAlgo.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef NULLC_STRALGO_H
-#define NULLC_STRALGO_H
 
 #include "stdafx.h"
 
@@ -111,5 +109,3 @@ struct InplaceStrHasher
 		return key.hash();
 	}
 };
-
-#endif

--- a/NULLC/Translator_X86.cpp
+++ b/NULLC/Translator_X86.cpp
@@ -4163,7 +4163,8 @@ void x86TestEncoding(unsigned char *codeLaunchHeader)
 
 	assert(stream < buf + bufSize);
 
-	char instBuf[128];
+	const unsigned instBufSize = 128;
+	char instBuf[instBufSize];
 
 	unsigned instCount = unsigned(ctx.GetLastInstruction() - instList);
 
@@ -4176,7 +4177,7 @@ void x86TestEncoding(unsigned char *codeLaunchHeader)
 
 	for(unsigned i = 0; i < instCount; i++)
 	{
-		instList[i].Decode(vmState, instBuf);
+		instList[i].Decode(vmState, instBuf, instBufSize);
 
 		output.Print(instBuf);
 		output.Print('\n');

--- a/NULLC/Translator_X86.cpp
+++ b/NULLC/Translator_X86.cpp
@@ -3963,7 +3963,7 @@ void x86TestEncoding(unsigned char *codeLaunchHeader)
 
 	unsigned instSize = 256 * 1024;
 	x86Instruction *instList = new x86Instruction[instSize];
-	memset(instList, 0, instSize * sizeof(x86Instruction));
+	NULLC::fillMemory(instList, 0, instSize * sizeof(x86Instruction));
 	ctx.SetLastInstruction(instList, instList);
 
 	stream += TestRptrXmmEncoding(ctx, stream, o_movss, x86MOVSS, testSizeDword);

--- a/NULLC/Translator_X86.h
+++ b/NULLC/Translator_X86.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Array.h"
 #include "Instruction_X86.h"
 
 void x86ResetLabels();

--- a/NULLC/Tree.h
+++ b/NULLC/Tree.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef NULLC_TREE_H
-#define NULLC_TREE_H
 
 namespace detail
 {
@@ -258,5 +256,3 @@ private:
 
 	node_type	*root;
 };
-
-#endif

--- a/NULLC/includes/dynamic.cpp
+++ b/NULLC/includes/dynamic.cpp
@@ -1,7 +1,10 @@
 #include "dynamic.h"
+
 #include "../nullc.h"
 #include "../nullbind.h"
 #include "../nullc_debug.h"
+
+#include "../StrAlgo.h"
 
 namespace NULLCDynamic
 {

--- a/NULLC/includes/io.cpp
+++ b/NULLC/includes/io.cpp
@@ -174,10 +174,7 @@ namespace NULLCIO
 		if(!writeFunc)
 			return;
 
-		char buf[128];
-		sprintf(buf, "%c", ch);
-
-		writeFunc(contextFunc, buf, (unsigned)strlen(buf));
+		writeFunc(contextFunc, &ch, 1);
 	}
 
 	void ReadIntFromConsole(int* val)

--- a/NULLC/includes/typeinfo.cpp
+++ b/NULLC/includes/typeinfo.cpp
@@ -3,6 +3,7 @@
 #include "../nullc.h"
 #include "../nullbind.h"
 #include "../Linker.h"
+#include "../StrAlgo.h"
 
 namespace NULLCTypeInfo
 {

--- a/NULLC/nullcdef.h
+++ b/NULLC/nullcdef.h
@@ -50,7 +50,6 @@ struct NULLCAutoArray
 
 #if defined(_MSC_VER) && defined(_DEBUG)
 //#define VERBOSE_DEBUG_OUTPUT
-//#define IMPORT_VERBOSE_DEBUG_OUTPUT
 //#define LINK_VERBOSE_DEBUG_OUTPUT
 #endif
 

--- a/NULLC/stdafx.cpp
+++ b/NULLC/stdafx.cpp
@@ -39,6 +39,16 @@ void NULLC::alignedDealloc(void* ptr)
 	dealloc(unaligned);
 }
 
+void NULLC::copyMemory(void* dst, const void* src, size_t size)
+{
+	memcpy(dst, src, size);
+}
+
+void NULLC::fillMemory(void* dst, int val, size_t size)
+{
+	memset(dst, val, size);
+}
+
 const char* NULLC::defaultFileLoad(const char* name, unsigned* size)
 {
 	assert(name);

--- a/NULLC/stdafx.h
+++ b/NULLC/stdafx.h
@@ -79,7 +79,3 @@ namespace NULLC
 	extern const char* (*fileLoad)(const char*, unsigned*);
 	extern void (*fileFree)(const char*);
 }
-
-#include "Array.h"
-#include "Pool.h"
-#include "StrAlgo.h"

--- a/NULLC/stdafx.h
+++ b/NULLC/stdafx.h
@@ -73,6 +73,9 @@ namespace NULLC
 		dealloc(ptr);
 	}
 
+	void copyMemory(void* dst, const void* src, size_t size);
+	void fillMemory(void* dst, int val, size_t size);
+
 	const char* defaultFileLoad(const char* name, unsigned* size);
 	void defaultFileFree(const char* data);
 

--- a/NULLC/stdafx.h
+++ b/NULLC/stdafx.h
@@ -16,19 +16,14 @@
 
 #include <new>
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdarg.h>
-#ifndef _MSC_VER
-	#include <stdint.h>
-#endif
-
-#include <string.h>
-#include <setjmp.h>
-
-#include <math.h>
-
 #include <assert.h>
+#include <math.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef NDEBUG
 #undef assert

--- a/nullc_ide/GUI/RichTextarea.cpp
+++ b/nullc_ide/GUI/RichTextarea.cpp
@@ -1,6 +1,7 @@
 #include "RichTextarea.h"
 
 #include "../ObjectPool.h"
+#include "../stdafx.h"
 
 #include "commctrl.h"
 #pragma comment(lib, "comctl32.lib")
@@ -1348,13 +1349,13 @@ VOID CALLBACK RichTextarea::AreaCursorUpdate(HWND hwnd, UINT uMsg, UINT_PTR idEv
 	if(areaStatus)
 	{
 		char buf[256];
-		snprintf(buf, 256, "Ln %d", data->cursorCharY + 1);
+		safeprintf(buf, 256, "Ln %d", data->cursorCharY + 1);
 		SendMessage(areaStatus, (WM_USER+1), 1, (LPARAM)buf);
-		snprintf(buf, 256, "Col %d", posInChars + 1);
+		safeprintf(buf, 256, "Col %d", posInChars + 1);
 		SendMessage(areaStatus, (WM_USER+1), 2, (LPARAM)buf);
-		snprintf(buf, 256, "Ch %d", data->cursorCharX + 1);
+		safeprintf(buf, 256, "Ch %d", data->cursorCharX + 1);
 		SendMessage(areaStatus, (WM_USER+1), 3, (LPARAM)buf);
-		snprintf(buf, 256, "%s", insertionMode ? "OVR" : "INS");
+		safeprintf(buf, 256, "%s", insertionMode ? "OVR" : "INS");
 		SendMessage(areaStatus, (WM_USER+1), 4, (LPARAM)buf);
 	}
 

--- a/nullc_ide/GUI/RichTextarea.cpp
+++ b/nullc_ide/GUI/RichTextarea.cpp
@@ -1348,13 +1348,13 @@ VOID CALLBACK RichTextarea::AreaCursorUpdate(HWND hwnd, UINT uMsg, UINT_PTR idEv
 	if(areaStatus)
 	{
 		char buf[256];
-		sprintf(buf, "Ln %d", data->cursorCharY + 1);
+		snprintf(buf, 256, "Ln %d", data->cursorCharY + 1);
 		SendMessage(areaStatus, (WM_USER+1), 1, (LPARAM)buf);
-		sprintf(buf, "Col %d", posInChars + 1);
+		snprintf(buf, 256, "Col %d", posInChars + 1);
 		SendMessage(areaStatus, (WM_USER+1), 2, (LPARAM)buf);
-		sprintf(buf, "Ch %d", data->cursorCharX + 1);
+		snprintf(buf, 256, "Ch %d", data->cursorCharX + 1);
 		SendMessage(areaStatus, (WM_USER+1), 3, (LPARAM)buf);
-		sprintf(buf, "%s", insertionMode ? "OVR" : "INS");
+		snprintf(buf, 256, "%s", insertionMode ? "OVR" : "INS");
 		SendMessage(areaStatus, (WM_USER+1), 4, (LPARAM)buf);
 	}
 

--- a/nullc_ide/main.cpp
+++ b/nullc_ide/main.cpp
@@ -31,6 +31,7 @@
 #include "../NULLC/nullc.h"
 #include "../NULLC/nullbind.h"
 #include "../NULLC/nullc_debug.h"
+#include "../NULLC/Array.h"
 #include "../NULLC/StrAlgo.h"
 
 #include "Colorer.h"

--- a/nullc_ide/main.cpp
+++ b/nullc_ide/main.cpp
@@ -359,6 +359,23 @@ double myGetPreciseTime()
 	return temp*1000.0;
 }
 
+// zero-terminated safe sprintf
+size_t safeprintf(char* dst, size_t size, const char* src, ...)
+{
+	if(size == 0)
+		return 0;
+
+	va_list args;
+	va_start(args, src);
+
+	int result = vsnprintf(dst, size, src, args);
+	dst[size - 1] = '\0';
+
+	va_end(args);
+
+	return result == -1 ? 0 : (unsigned(result) > size ? size : result);
+}
+
 const char* GetLastNullcErrorWindows()
 {
 	const char *src = nullcGetLastError();
@@ -1009,23 +1026,6 @@ bool InitInstance(HINSTANCE hInstance, int nCmdShow)
 	SetTimer(hWnd, 1, 100, 0);
 
 	return TRUE;
-}
-
-// zero-terminated safe sprintf
-size_t safeprintf(char* dst, size_t size, const char* src, ...)
-{
-	if(size == 0)
-		return 0;
-
-	va_list args;
-	va_start(args, src);
-
-	int result = vsnprintf(dst, size, src, args);
-	dst[size - 1] = '\0';
-
-	va_end(args);
-
-	return result == -1 ? 0 : (unsigned(result) > size ? size : result);
 }
 
 ExternVarInfo	*codeVars = NULL;
@@ -1789,8 +1789,8 @@ DWORD WINAPI CalcThread(void* param)
 		SetWindowText(hResult, "Finalizing...");
 		nullcFinalize();
 
-		char	result[1024];
-		_snprintf(result, 1024, "The answer is: %s [in %f]", val, runRes.time);
+		char result[1024];
+		safeprintf(result, 1024, "The answer is: %s [in %f]", val, runRes.time);
 		result[1023] = '\0';
 		SetWindowText(hResult, result);
 	}
@@ -2102,7 +2102,7 @@ void IdeRun(bool debug)
 				if(goodRun)
 				{
 					char result[1024];
-					_snprintf(result, 1024, "The answer is: %s [in %f]", val, runRes.time);
+					safeprintf(result, 1024, "The answer is: %s [in %f]", val, runRes.time);
 					result[1023] = '\0';
 					SetWindowText(hResult, result);
 				}
@@ -2133,7 +2133,7 @@ void IdeRun(bool debug)
 				if(goodRun)
 				{
 					char result[1024];
-					_snprintf(result, 1024, "The answer is: %s [in %f]", val, runRes.time);
+					safeprintf(result, 1024, "The answer is: %s [in %f]", val, runRes.time);
 					result[1023] = '\0';
 					SetWindowText(hResult, result);
 				}

--- a/nullc_ide/main.cpp
+++ b/nullc_ide/main.cpp
@@ -1913,18 +1913,19 @@ bool CheckFile(const char *name)
 
 std::string ResolveSourceFile(const char* name)
 {
-	char tmp[256];
-	sprintf(tmp, "%s", name);
+	const unsigned tmpLength = 1024;
+	char tmp[tmpLength];
+	safeprintf(tmp, tmpLength, "%s", name);
 
 	if(CheckFile(tmp))
 		return tmp;
 
-	sprintf(tmp, "translation/%s", name);
+	safeprintf(tmp, tmpLength, "translation/%s", name);
 
 	if(CheckFile(tmp))
 		return tmp;
 
-	sprintf(tmp, "../NULLC/translation/%s", name);
+	safeprintf(tmp, tmpLength, "../NULLC/translation/%s", name);
 
 	if(CheckFile(tmp))
 		return tmp;
@@ -2017,8 +2018,9 @@ void IdeUpdateModuleImportPaths(TabbedFiles::TabInfo *info)
 
 	if(const char *pos = strrchr(info->name, '\\'))
 	{
-		char path[512];
-		NULLC::SafeSprintf(path, 1024, "%.*s", unsigned(pos - info->name) + 1, info->name);
+		const unsigned pathLength = 1024;
+		char path[pathLength];
+		safeprintf(path, pathLength, "%.*s", unsigned(pos - info->name) + 1, info->name);
 
 		for(unsigned i = 0; i < unsigned(strlen(path)); i++)
 			path[i] = path[i] == '\\' ? '/' : path[i];

--- a/nullc_ide/stdafx.h
+++ b/nullc_ide/stdafx.h
@@ -1,12 +1,6 @@
 #pragma once
 #pragma warning(disable: 4275)
 #pragma warning(disable: 4005)
-/*
-#define SUPER_CALC_ON
-#include "MemoryMan/platform.h"
-#include "MemoryMan/MemoryMan.h"
-#pragma comment(lib, "lib/debuglib/MemoryMan.lib")
-#undef pure*/
 
 #include <stdlib.h>
 
@@ -21,3 +15,4 @@
 #include <time.h>
 
 double myGetPreciseTime();
+size_t safeprintf(char* dst, size_t size, const char* src, ...);

--- a/nullcl/main.cpp
+++ b/nullcl/main.cpp
@@ -7,6 +7,20 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdarg.h>
+
+size_t format(char* dst, size_t size, const char* src, ...)
+{
+	va_list args;
+	va_start(args, src);
+
+	int result = vsnprintf(dst, size, src, args);
+	dst[size - 1] = '\0';
+
+	va_end(args);
+
+	return result == -1 ? 0 : (unsigned(result) > size ? size : result);
+}
 
 const char* translationDependencies[128];
 unsigned translationDependencyCount = 0;
@@ -37,22 +51,22 @@ bool SearchAndAddSourceFile(char*& buf, const char* name)
 {
 	const unsigned tmpSize = 256;
 	char tmp[tmpSize];
-	snprintf(tmp, tmpSize, "%s", name);
+	format(tmp, tmpSize, "%s", name);
 
 	if(AddSourceFile(buf, tmp))
 		return true;
 
-	snprintf(tmp, tmpSize, "translation/%s", name);
+	format(tmp, tmpSize, "translation/%s", name);
 
 	if(AddSourceFile(buf, tmp))
 		return true;
 
-	snprintf(tmp, tmpSize, "NULLC/translation/%s", name);
+	format(tmp, tmpSize, "NULLC/translation/%s", name);
 
 	if(AddSourceFile(buf, tmp))
 		return true;
 
-	snprintf(tmp, tmpSize, "../NULLC/translation/%s", name);
+	format(tmp, tmpSize, "../NULLC/translation/%s", name);
 
 	if(AddSourceFile(buf, tmp))
 		return true;
@@ -209,7 +223,7 @@ int main(int argc, char** argv)
 				if(strstr(dependency, "import_"))
 				{
 					char tmp[256];
-					snprintf(tmp, 256, "%s", dependency + strlen("import_"));
+					format(tmp, 256, "%s", dependency + strlen("import_"));
 
 					if(char *pos = strstr(tmp, "_nc.cpp"))
 						strcpy(pos, "_bind.cpp");

--- a/nullcl/main.cpp
+++ b/nullcl/main.cpp
@@ -35,23 +35,24 @@ bool AddSourceFile(char *&buf, const char *name)
 
 bool SearchAndAddSourceFile(char*& buf, const char* name)
 {
-	char tmp[256];
-	sprintf(tmp, "%s", name);
+	const unsigned tmpSize = 256;
+	char tmp[tmpSize];
+	snprintf(tmp, tmpSize, "%s", name);
 
 	if(AddSourceFile(buf, tmp))
 		return true;
 
-	sprintf(tmp, "translation/%s", name);
+	snprintf(tmp, tmpSize, "translation/%s", name);
 
 	if(AddSourceFile(buf, tmp))
 		return true;
 
-	sprintf(tmp, "NULLC/translation/%s", name);
+	snprintf(tmp, tmpSize, "NULLC/translation/%s", name);
 
 	if(AddSourceFile(buf, tmp))
 		return true;
 
-	sprintf(tmp, "../NULLC/translation/%s", name);
+	snprintf(tmp, tmpSize, "../NULLC/translation/%s", name);
 
 	if(AddSourceFile(buf, tmp))
 		return true;
@@ -208,7 +209,7 @@ int main(int argc, char** argv)
 				if(strstr(dependency, "import_"))
 				{
 					char tmp[256];
-					sprintf(tmp, "%s", dependency + strlen("import_"));
+					snprintf(tmp, 256, "%s", dependency + strlen("import_"));
 
 					if(char *pos = strstr(tmp, "_nc.cpp"))
 						strcpy(pos, "_bind.cpp");

--- a/tests/TestRun.cpp
+++ b/tests/TestRun.cpp
@@ -72,14 +72,14 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 			exprDone = true;
 
 			if(strchr(exprResult, '.'))
-				sprintf(exprResult, "%d", int(atof(exprResult) + 0.5));
+				snprintf(exprResult, 256, "%d", int(atof(exprResult) + 0.5));
 		}
 
 		char instResult[256];
 		if(nullcTestEvaluateInstructionTree(instResult, 256))
 		{
 			if(strchr(instResult, '.'))
-				sprintf(instResult, "%d", int(atof(instResult) + 0.5));
+				snprintf(instResult, 256, "%d", int(atof(instResult) + 0.5));
 
 			if(exprDone)
 				assert(strcmp(exprResult, instResult) == 0);


### PR DESCRIPTION
This should fix https://github.com/WheretIB/nullc/issues/36 (aside from warnings in external pugixml library)
And also https://github.com/WheretIB/nullc/issues/38 (there is an existing PR with the fix for this, but it includes many other changes)