### PR TITLE
Fixed missing pointer cast in rviMemCopy null pointer check

### DIFF
--- a/NULLC/Android.mk
+++ b/NULLC/Android.mk
@@ -63,6 +63,7 @@ LOCAL_SRC_FILES += NULLC/includes/vector.cpp
 
 # std
 LOCAL_SRC_FILES += NULLC/includes/dynamic.cpp
+LOCAL_SRC_FILES += NULLC/includes/error.cpp
 LOCAL_SRC_FILES += NULLC/includes/file.cpp
 LOCAL_SRC_FILES += NULLC/includes/gc.cpp
 LOCAL_SRC_FILES += NULLC/includes/io.cpp
@@ -95,6 +96,6 @@ LOCAL_SRC_FILES += external/dyncall/dyncall_call.S
 
 LOCAL_ARM_MODE := arm
 
-LOCAL_CFLAGS += -DARM -DNULLC_USE_DYNCALL -fsigned-char -fno-omit-frame-pointer
+LOCAL_CFLAGS += -DARM -fsigned-char -fno-omit-frame-pointer
 
 include $(BUILD_SHARED_LIBRARY)

--- a/NULLC/Executor_RegVm.cpp
+++ b/NULLC/Executor_RegVm.cpp
@@ -752,10 +752,10 @@ RegVmReturnType ExecutorRegVm::RunCode(RegVmCmd *instruction, RegVmRegister * co
 			instruction++;
 			BREAK;
 		CASE(rviMemCopy)
-			if(regFilePtr[cmd.rA].ptrValue < 0x00010000)
+			if((uintptr_t)regFilePtr[cmd.rA].ptrValue < 0x00010000)
 				return rvm->ExecError(instruction, "ERROR: null pointer access");
 
-			if(regFilePtr[cmd.rC].ptrValue < 0x00010000)
+			if((uintptr_t)regFilePtr[cmd.rC].ptrValue < 0x00010000)
 				return rvm->ExecError(instruction, "ERROR: null pointer access");
 
 			memcpy((void*)regFilePtr[cmd.rA].ptrValue, (void*)regFilePtr[cmd.rC].ptrValue, cmd.argument);

--- a/NULLC/TypeTree.cpp
+++ b/NULLC/TypeTree.cpp
@@ -670,7 +670,8 @@ InplaceStr GetTemporaryName(ExpressionContext &ctx, unsigned index, const char *
 
 	unsigned suffixLength = suffix ? (unsigned)strlen(suffix) : 0;
 
-	char *name = (char*)ctx.allocator->alloc(16 + suffixLength);
+	unsigned nameLength = 16 + suffixLength;
+	char *name = (char*)ctx.allocator->alloc(nameLength);
 
 	char *pos = name;
 
@@ -694,6 +695,7 @@ InplaceStr GetTemporaryName(ExpressionContext &ctx, unsigned index, const char *
 
 	*pos = 0;
 
+	assert(strlen(name) < nameLength);
 	return InplaceStr(name, pos);
 }
 

--- a/NULLC/nullc_android.cpp
+++ b/NULLC/nullc_android.cpp
@@ -292,7 +292,7 @@ JNIEXPORT jboolean JNICALL Java_org_nullc_Nullc_nullcRunFunction(JNIEnv *env, jc
 
 	ExternFuncInfo &function = functions[func.id];
 
-	char *argBuf = (char*)NULLC::alloc(function.bytesToPop + sizeof(void*));
+	char *argBuf = (char*)NULLC::alloc(function.argumentSize + sizeof(void*));
 
 	jsize argCount = env->GetArrayLength(arguments);
 


### PR DESCRIPTION
Thanks to @mingodad for bringing up the issue and the fix.

This PR also includes a fix to Android build.